### PR TITLE
fix(chart): render service-base templates

### DIFF
--- a/charts/telegram-connector/Chart.yaml
+++ b/charts/telegram-connector/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: telegram-connector
 description: Helm chart for deploying the Telegram Connector service.
 type: application
-version: 0.1.0
-appVersion: 0.1.0
+version: 0.1.1
+appVersion: 0.1.1
 home: https://github.com/agynio/telegram-connector
 sources:
   - https://github.com/agynio/telegram-connector

--- a/charts/telegram-connector/templates/service-base.yaml
+++ b/charts/telegram-connector/templates/service-base.yaml
@@ -1,0 +1,15 @@
+{{ include "service-base.rbac" . }}
+---
+{{ include "service-base.serviceAccount" . }}
+---
+{{ include "service-base.service" . }}
+---
+{{ include "service-base.deployment" . }}
+---
+{{ include "service-base.hpa" . }}
+---
+{{ include "service-base.ingress" . }}
+---
+{{ include "service-base.pdb" . }}
+---
+{{ include "service-base.metrics" . }}


### PR DESCRIPTION
## Summary
- add service-base wrapper template so dependency resources render
- bump chart/app version to 0.1.1 for patch release readiness
- verify chart renders non-empty manifests via helm template

## Testing
- helm dependency build charts/telegram-connector
- helm lint charts/telegram-connector
- helm template charts/telegram-connector > /tmp/telegram-connector-template.yaml
- go vet ./...
- go test ./...

Closes #5