### PR TITLE
fix(image): use numeric uid

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,8 +47,8 @@ WORKDIR /app
 
 COPY --from=build /out/telegram-connector /app/telegram-connector
 
-RUN addgroup -S app && adduser -S app -G app
+RUN addgroup -S -g 10001 app && adduser -S -D -H -u 10001 -G app app
 
-USER app
+USER 10001
 
 ENTRYPOINT ["/app/telegram-connector"]


### PR DESCRIPTION
## Summary
- create deterministic uid/gid 10001 for the runtime user
- run the container as numeric uid (USER 10001) to satisfy runAsNonRoot

## Testing
- helm dependency build charts/telegram-connector
- helm lint charts/telegram-connector
- helm template charts/telegram-connector > /tmp/telegram-connector-template.yaml
- go vet ./...
- go test ./...

Closes #5