### PR TITLE
feat(connector): handle degraded threads

### DIFF
--- a/internal/connector/inbound.go
+++ b/internal/connector/inbound.go
@@ -2,11 +2,13 @@ package connector
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"strings"
 	"time"
 
+	"connectrpc.com/connect"
 	"github.com/google/uuid"
 
 	filesv1 "github.com/agynio/telegram-connector/.gen/go/agynio/api/files/v1"
@@ -14,7 +16,10 @@ import (
 	"github.com/agynio/telegram-connector/internal/telegram"
 )
 
-const inboundRetryDelay = time.Second
+const (
+	inboundRetryDelay     = time.Second
+	degradedThreadMessage = "thread is degraded"
+)
 
 func (w *installationWorker) runInbound(ctx context.Context) error {
 	lastUpdateID, err := w.loadInstallationState(ctx)
@@ -117,40 +122,69 @@ func (w *installationWorker) handleUpdate(ctx context.Context, update telegram.U
 			return err
 		}
 	}
-
-	threadID := mapping.ThreadID
 	if !found {
-		thread, err := w.gateway.CreateThread(ctx, w.installation.OrganizationID.String())
+		var err error
+		mapping, err = w.createThreadMapping(ctx, message.Chat.ID, message.From.ID)
 		if err != nil {
 			return err
 		}
-		threadUUID, err := uuid.Parse(thread.GetId())
-		if err != nil {
-			return fmt.Errorf("invalid thread id: %w", err)
-		}
-		if err := w.gateway.AddParticipant(ctx, w.installation.OrganizationID.String(), thread.GetId(), w.installation.AgentID.String()); err != nil {
-			return err
-		}
-		mapping, err = w.store.CreateChatMapping(ctx, store.ChatMappingInput{
-			InstallationID: w.installation.ID,
-			TelegramChatID: message.Chat.ID,
-			TelegramUserID: message.From.ID,
-			ThreadID:       threadUUID,
-		})
-		if err != nil {
-			return err
-		}
-		threadID = mapping.ThreadID
 	}
 
 	body, fileIDs, err := w.buildInboundMessage(ctx, message)
 	if err != nil {
 		return err
 	}
+	threadID := mapping.ThreadID
 	if err := w.gateway.SendMessage(ctx, threadID.String(), body, fileIDs); err != nil {
-		return err
+		if !isThreadDegradedError(err) {
+			return err
+		}
+		log.Printf("connector: thread %s degraded for chat %d", threadID.String(), message.Chat.ID)
+		mapping, err = w.remapThreadMapping(ctx, message)
+		if err != nil {
+			return err
+		}
+		threadID = mapping.ThreadID
+		if err := w.gateway.SendMessage(ctx, threadID.String(), body, fileIDs); err != nil {
+			if isThreadDegradedError(err) {
+				log.Printf("connector: remapped thread %s degraded for chat %d", threadID.String(), message.Chat.ID)
+				return nil
+			}
+			return err
+		}
 	}
 	return nil
+}
+
+func (w *installationWorker) createThreadMapping(ctx context.Context, chatID, userID int64) (store.ChatMapping, error) {
+	thread, err := w.gateway.CreateThread(ctx, w.installation.OrganizationID.String())
+	if err != nil {
+		return store.ChatMapping{}, err
+	}
+	threadUUID, err := uuid.Parse(thread.GetId())
+	if err != nil {
+		return store.ChatMapping{}, fmt.Errorf("invalid thread id: %w", err)
+	}
+	if err := w.gateway.AddParticipant(ctx, w.installation.OrganizationID.String(), thread.GetId(), w.installation.AgentID.String()); err != nil {
+		return store.ChatMapping{}, err
+	}
+	mapping, err := w.store.CreateChatMapping(ctx, store.ChatMappingInput{
+		InstallationID: w.installation.ID,
+		TelegramChatID: chatID,
+		TelegramUserID: userID,
+		ThreadID:       threadUUID,
+	})
+	if err != nil {
+		return store.ChatMapping{}, err
+	}
+	return mapping, nil
+}
+
+func (w *installationWorker) remapThreadMapping(ctx context.Context, message *telegram.Message) (store.ChatMapping, error) {
+	if err := w.store.DeleteChatMapping(ctx, w.installation.ID, message.Chat.ID); err != nil {
+		return store.ChatMapping{}, err
+	}
+	return w.createThreadMapping(ctx, message.Chat.ID, message.From.ID)
 }
 
 func (w *installationWorker) buildInboundMessage(ctx context.Context, message *telegram.Message) (string, []string, error) {
@@ -233,6 +267,14 @@ func (w *installationWorker) uploadTelegramFile(ctx context.Context, fileID, fil
 		return "", err
 	}
 	return uploaded.GetId(), nil
+}
+
+func isThreadDegradedError(err error) bool {
+	var connectErr *connect.Error
+	if errors.As(err, &connectErr) {
+		return connectErr.Code() == connect.CodeFailedPrecondition && connectErr.Message() == degradedThreadMessage
+	}
+	return false
 }
 
 func largestPhoto(photos []telegram.Photo) telegram.Photo {

--- a/internal/connector/inbound_test.go
+++ b/internal/connector/inbound_test.go
@@ -1,0 +1,389 @@
+package connector
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/google/uuid"
+
+	appsv1 "github.com/agynio/telegram-connector/.gen/go/agynio/api/apps/v1"
+	filesv1 "github.com/agynio/telegram-connector/.gen/go/agynio/api/files/v1"
+	notificationsv1 "github.com/agynio/telegram-connector/.gen/go/agynio/api/notifications/v1"
+	threadsv1 "github.com/agynio/telegram-connector/.gen/go/agynio/api/threads/v1"
+	"github.com/agynio/telegram-connector/internal/store"
+	"github.com/agynio/telegram-connector/internal/telegram"
+)
+
+type stubGateway struct {
+	t                *testing.T
+	appIdentityID    string
+	createThreadFn   func(context.Context, string) (*threadsv1.Thread, error)
+	addParticipantFn func(context.Context, string, string, string) error
+	sendMessageFn    func(context.Context, string, string, []string) error
+}
+
+func (s *stubGateway) AppIdentityID() string {
+	return s.appIdentityID
+}
+
+func (s *stubGateway) ListInstallations(ctx context.Context, appID string) ([]*appsv1.Installation, error) {
+	s.t.Fatalf("unexpected ListInstallations")
+	return nil, nil
+}
+
+func (s *stubGateway) CreateThread(ctx context.Context, organizationID string) (*threadsv1.Thread, error) {
+	if s.createThreadFn == nil {
+		s.t.Fatalf("unexpected CreateThread")
+	}
+	return s.createThreadFn(ctx, organizationID)
+}
+
+func (s *stubGateway) AddParticipant(ctx context.Context, organizationID, threadID, participantID string) error {
+	if s.addParticipantFn == nil {
+		s.t.Fatalf("unexpected AddParticipant")
+	}
+	return s.addParticipantFn(ctx, organizationID, threadID, participantID)
+}
+
+func (s *stubGateway) SendMessage(ctx context.Context, threadID, body string, fileIDs []string) error {
+	if s.sendMessageFn == nil {
+		s.t.Fatalf("unexpected SendMessage")
+	}
+	return s.sendMessageFn(ctx, threadID, body, fileIDs)
+}
+
+func (s *stubGateway) GetUnackedMessages(ctx context.Context) ([]*threadsv1.Message, error) {
+	s.t.Fatalf("unexpected GetUnackedMessages")
+	return nil, nil
+}
+
+func (s *stubGateway) AckMessages(ctx context.Context, messageIDs []string) error {
+	s.t.Fatalf("unexpected AckMessages")
+	return nil
+}
+
+func (s *stubGateway) Subscribe(ctx context.Context) (*connect.ServerStreamForClient[notificationsv1.SubscribeResponse], error) {
+	s.t.Fatalf("unexpected Subscribe")
+	return nil, nil
+}
+
+func (s *stubGateway) UploadFile(ctx context.Context, metadata *filesv1.UploadFileMetadata, payload []byte) (*filesv1.FileInfo, error) {
+	s.t.Fatalf("unexpected UploadFile")
+	return nil, nil
+}
+
+func (s *stubGateway) GetFileMetadata(ctx context.Context, fileID string) (*filesv1.FileInfo, error) {
+	s.t.Fatalf("unexpected GetFileMetadata")
+	return nil, nil
+}
+
+func (s *stubGateway) GetFileContent(ctx context.Context, fileID string) ([]byte, error) {
+	s.t.Fatalf("unexpected GetFileContent")
+	return nil, nil
+}
+
+type stubStore struct {
+	t                      *testing.T
+	getChatMappingFn       func(context.Context, uuid.UUID, int64) (store.ChatMapping, bool, error)
+	createChatMappingFn    func(context.Context, store.ChatMappingInput) (store.ChatMapping, error)
+	deleteChatMappingFn    func(context.Context, uuid.UUID, int64) error
+	clearChatBlockedFn     func(context.Context, uuid.UUID, int64) error
+	markChatBlockedFn      func(context.Context, uuid.UUID, int64) error
+	getInstallationStateFn func(context.Context, uuid.UUID) (int64, error)
+	upsertStateFn          func(context.Context, uuid.UUID, int64) error
+}
+
+func (s *stubStore) GetChatMapping(ctx context.Context, installationID uuid.UUID, chatID int64) (store.ChatMapping, bool, error) {
+	if s.getChatMappingFn == nil {
+		s.t.Fatalf("unexpected GetChatMapping")
+	}
+	return s.getChatMappingFn(ctx, installationID, chatID)
+}
+
+func (s *stubStore) GetChatMappingByThreadID(ctx context.Context, installationID, threadID uuid.UUID) (store.ChatMapping, bool, error) {
+	s.t.Fatalf("unexpected GetChatMappingByThreadID")
+	return store.ChatMapping{}, false, nil
+}
+
+func (s *stubStore) CreateChatMapping(ctx context.Context, input store.ChatMappingInput) (store.ChatMapping, error) {
+	if s.createChatMappingFn == nil {
+		s.t.Fatalf("unexpected CreateChatMapping")
+	}
+	return s.createChatMappingFn(ctx, input)
+}
+
+func (s *stubStore) DeleteChatMapping(ctx context.Context, installationID uuid.UUID, chatID int64) error {
+	if s.deleteChatMappingFn == nil {
+		s.t.Fatalf("unexpected DeleteChatMapping")
+	}
+	return s.deleteChatMappingFn(ctx, installationID, chatID)
+}
+
+func (s *stubStore) ClearChatBlocked(ctx context.Context, installationID uuid.UUID, chatID int64) error {
+	if s.clearChatBlockedFn == nil {
+		s.t.Fatalf("unexpected ClearChatBlocked")
+	}
+	return s.clearChatBlockedFn(ctx, installationID, chatID)
+}
+
+func (s *stubStore) MarkChatBlocked(ctx context.Context, installationID uuid.UUID, chatID int64) error {
+	if s.markChatBlockedFn == nil {
+		s.t.Fatalf("unexpected MarkChatBlocked")
+	}
+	return s.markChatBlockedFn(ctx, installationID, chatID)
+}
+
+func (s *stubStore) GetInstallationState(ctx context.Context, installationID uuid.UUID) (int64, error) {
+	if s.getInstallationStateFn == nil {
+		s.t.Fatalf("unexpected GetInstallationState")
+	}
+	return s.getInstallationStateFn(ctx, installationID)
+}
+
+func (s *stubStore) UpsertInstallationState(ctx context.Context, installationID uuid.UUID, lastUpdateID int64) error {
+	if s.upsertStateFn == nil {
+		s.t.Fatalf("unexpected UpsertInstallationState")
+	}
+	return s.upsertStateFn(ctx, installationID, lastUpdateID)
+}
+
+func TestIsThreadDegradedError(t *testing.T) {
+	err := fmt.Errorf("send message: %w", connect.NewError(connect.CodeFailedPrecondition, errors.New(degradedThreadMessage)))
+	if !isThreadDegradedError(err) {
+		t.Fatal("expected degraded error")
+	}
+	notDegraded := connect.NewError(connect.CodeFailedPrecondition, errors.New("other"))
+	if isThreadDegradedError(notDegraded) {
+		t.Fatal("expected non-degraded error")
+	}
+}
+
+func TestHandleUpdateRemapsOnDegradedThread(t *testing.T) {
+	installationID := uuid.New()
+	organizationID := uuid.New()
+	agentID := uuid.New()
+	chatID := int64(44)
+	userID := int64(77)
+	oldThreadID := uuid.New()
+	newThreadID := uuid.New()
+	degradedErr := fmt.Errorf("send message: %w", connect.NewError(connect.CodeFailedPrecondition, errors.New(degradedThreadMessage)))
+
+	deleteCalled := false
+	createMappingCalled := false
+	sendCalls := make([]string, 0, 2)
+	addParticipantCalled := false
+	createThreadCalled := false
+
+	storeStub := &stubStore{
+		t: t,
+		getChatMappingFn: func(_ context.Context, installationArg uuid.UUID, chatIDArg int64) (store.ChatMapping, bool, error) {
+			if installationArg != installationID {
+				t.Fatalf("expected installation %s, got %s", installationID, installationArg)
+			}
+			if chatIDArg != chatID {
+				t.Fatalf("expected chat %d, got %d", chatID, chatIDArg)
+			}
+			return store.ChatMapping{
+				InstallationID: installationID,
+				TelegramChatID: chatID,
+				TelegramUserID: userID,
+				ThreadID:       oldThreadID,
+			}, true, nil
+		},
+		deleteChatMappingFn: func(_ context.Context, installationArg uuid.UUID, chatIDArg int64) error {
+			deleteCalled = true
+			if installationArg != installationID {
+				t.Fatalf("expected installation %s, got %s", installationID, installationArg)
+			}
+			if chatIDArg != chatID {
+				t.Fatalf("expected chat %d, got %d", chatID, chatIDArg)
+			}
+			return nil
+		},
+		createChatMappingFn: func(_ context.Context, input store.ChatMappingInput) (store.ChatMapping, error) {
+			createMappingCalled = true
+			if input.InstallationID != installationID {
+				t.Fatalf("expected installation %s, got %s", installationID, input.InstallationID)
+			}
+			if input.TelegramChatID != chatID {
+				t.Fatalf("expected chat %d, got %d", chatID, input.TelegramChatID)
+			}
+			if input.TelegramUserID != userID {
+				t.Fatalf("expected user %d, got %d", userID, input.TelegramUserID)
+			}
+			if input.ThreadID != newThreadID {
+				t.Fatalf("expected thread %s, got %s", newThreadID, input.ThreadID)
+			}
+			return store.ChatMapping{
+				InstallationID: installationID,
+				TelegramChatID: chatID,
+				TelegramUserID: userID,
+				ThreadID:       newThreadID,
+				CreatedAt:      time.Now().UTC(),
+			}, nil
+		},
+		clearChatBlockedFn: func(context.Context, uuid.UUID, int64) error {
+			t.Fatal("unexpected ClearChatBlocked")
+			return nil
+		},
+		markChatBlockedFn: func(context.Context, uuid.UUID, int64) error {
+			t.Fatal("unexpected MarkChatBlocked")
+			return nil
+		},
+		getInstallationStateFn: func(context.Context, uuid.UUID) (int64, error) {
+			t.Fatal("unexpected GetInstallationState")
+			return 0, nil
+		},
+		upsertStateFn: func(context.Context, uuid.UUID, int64) error {
+			t.Fatal("unexpected UpsertInstallationState")
+			return nil
+		},
+	}
+
+	gatewayStub := &stubGateway{
+		t: t,
+		createThreadFn: func(_ context.Context, organizationArg string) (*threadsv1.Thread, error) {
+			createThreadCalled = true
+			if organizationArg != organizationID.String() {
+				t.Fatalf("expected organization %s, got %s", organizationID, organizationArg)
+			}
+			return &threadsv1.Thread{Id: newThreadID.String()}, nil
+		},
+		addParticipantFn: func(_ context.Context, organizationArg, threadArg, participantArg string) error {
+			addParticipantCalled = true
+			if organizationArg != organizationID.String() {
+				t.Fatalf("expected organization %s, got %s", organizationID, organizationArg)
+			}
+			if threadArg != newThreadID.String() {
+				t.Fatalf("expected thread %s, got %s", newThreadID, threadArg)
+			}
+			if participantArg != agentID.String() {
+				t.Fatalf("expected agent %s, got %s", agentID, participantArg)
+			}
+			return nil
+		},
+		sendMessageFn: func(_ context.Context, threadArg, body string, fileIDs []string) error {
+			sendCalls = append(sendCalls, threadArg)
+			if threadArg == oldThreadID.String() {
+				return degradedErr
+			}
+			if threadArg == newThreadID.String() {
+				return nil
+			}
+			return fmt.Errorf("unexpected thread %s", threadArg)
+		},
+	}
+
+	worker := newInstallationWorker(Installation{
+		ID:             installationID,
+		OrganizationID: organizationID,
+		BotToken:       "token",
+		AgentID:        agentID,
+	}, storeStub, gatewayStub, "http://telegram.test", time.Second)
+
+	update := telegram.Update{Message: &telegram.Message{
+		From: &telegram.User{ID: userID},
+		Chat: telegram.Chat{ID: chatID, Type: "private"},
+		Text: "hello",
+	}}
+
+	if err := worker.handleUpdate(context.Background(), update); err != nil {
+		t.Fatalf("handleUpdate returned error: %v", err)
+	}
+	if !deleteCalled {
+		t.Fatal("expected DeleteChatMapping to be called")
+	}
+	if !createThreadCalled {
+		t.Fatal("expected CreateThread to be called")
+	}
+	if !addParticipantCalled {
+		t.Fatal("expected AddParticipant to be called")
+	}
+	if !createMappingCalled {
+		t.Fatal("expected CreateChatMapping to be called")
+	}
+	if len(sendCalls) != 2 {
+		t.Fatalf("expected 2 SendMessage calls, got %d", len(sendCalls))
+	}
+	if sendCalls[0] != oldThreadID.String() || sendCalls[1] != newThreadID.String() {
+		t.Fatalf("expected send to old then new thread, got %v", sendCalls)
+	}
+}
+
+func TestHandleUpdateStopsAfterSecondDegradedSend(t *testing.T) {
+	installationID := uuid.New()
+	organizationID := uuid.New()
+	agentID := uuid.New()
+	chatID := int64(11)
+	userID := int64(22)
+	oldThreadID := uuid.New()
+	newThreadID := uuid.New()
+	degradedErr := fmt.Errorf("send message: %w", connect.NewError(connect.CodeFailedPrecondition, errors.New(degradedThreadMessage)))
+
+	storeStub := &stubStore{
+		t: t,
+		getChatMappingFn: func(context.Context, uuid.UUID, int64) (store.ChatMapping, bool, error) {
+			return store.ChatMapping{
+				InstallationID: installationID,
+				TelegramChatID: chatID,
+				TelegramUserID: userID,
+				ThreadID:       oldThreadID,
+			}, true, nil
+		},
+		deleteChatMappingFn: func(context.Context, uuid.UUID, int64) error {
+			return nil
+		},
+		createChatMappingFn: func(context.Context, store.ChatMappingInput) (store.ChatMapping, error) {
+			return store.ChatMapping{ThreadID: newThreadID}, nil
+		},
+		clearChatBlockedFn: func(context.Context, uuid.UUID, int64) error {
+			return nil
+		},
+		markChatBlockedFn: func(context.Context, uuid.UUID, int64) error {
+			t.Fatal("unexpected MarkChatBlocked")
+			return nil
+		},
+		getInstallationStateFn: func(context.Context, uuid.UUID) (int64, error) {
+			t.Fatal("unexpected GetInstallationState")
+			return 0, nil
+		},
+		upsertStateFn: func(context.Context, uuid.UUID, int64) error {
+			t.Fatal("unexpected UpsertInstallationState")
+			return nil
+		},
+	}
+
+	gatewayStub := &stubGateway{
+		t: t,
+		createThreadFn: func(context.Context, string) (*threadsv1.Thread, error) {
+			return &threadsv1.Thread{Id: newThreadID.String()}, nil
+		},
+		addParticipantFn: func(context.Context, string, string, string) error {
+			return nil
+		},
+		sendMessageFn: func(context.Context, string, string, []string) error {
+			return degradedErr
+		},
+	}
+
+	worker := newInstallationWorker(Installation{
+		ID:             installationID,
+		OrganizationID: organizationID,
+		BotToken:       "token",
+		AgentID:        agentID,
+	}, storeStub, gatewayStub, "http://telegram.test", time.Second)
+
+	update := telegram.Update{Message: &telegram.Message{
+		From: &telegram.User{ID: userID},
+		Chat: telegram.Chat{ID: chatID, Type: "private"},
+		Text: "hello",
+	}}
+
+	if err := worker.handleUpdate(context.Background(), update); err != nil {
+		t.Fatalf("handleUpdate returned error: %v", err)
+	}
+}

--- a/internal/connector/service.go
+++ b/internal/connector/service.go
@@ -7,10 +7,13 @@ import (
 	"sync"
 	"time"
 
+	"connectrpc.com/connect"
 	"github.com/google/uuid"
 
 	appsv1 "github.com/agynio/telegram-connector/.gen/go/agynio/api/apps/v1"
-	"github.com/agynio/telegram-connector/internal/gateway"
+	filesv1 "github.com/agynio/telegram-connector/.gen/go/agynio/api/files/v1"
+	notificationsv1 "github.com/agynio/telegram-connector/.gen/go/agynio/api/notifications/v1"
+	threadsv1 "github.com/agynio/telegram-connector/.gen/go/agynio/api/threads/v1"
 	"github.com/agynio/telegram-connector/internal/store"
 )
 
@@ -20,15 +23,30 @@ type Store interface {
 	GetChatMapping(ctx context.Context, installationID uuid.UUID, chatID int64) (store.ChatMapping, bool, error)
 	GetChatMappingByThreadID(ctx context.Context, installationID, threadID uuid.UUID) (store.ChatMapping, bool, error)
 	CreateChatMapping(ctx context.Context, input store.ChatMappingInput) (store.ChatMapping, error)
+	DeleteChatMapping(ctx context.Context, installationID uuid.UUID, chatID int64) error
 	ClearChatBlocked(ctx context.Context, installationID uuid.UUID, chatID int64) error
 	MarkChatBlocked(ctx context.Context, installationID uuid.UUID, chatID int64) error
 	GetInstallationState(ctx context.Context, installationID uuid.UUID) (int64, error)
 	UpsertInstallationState(ctx context.Context, installationID uuid.UUID, lastUpdateID int64) error
 }
 
+type Gateway interface {
+	AppIdentityID() string
+	ListInstallations(ctx context.Context, appID string) ([]*appsv1.Installation, error)
+	CreateThread(ctx context.Context, organizationID string) (*threadsv1.Thread, error)
+	AddParticipant(ctx context.Context, organizationID, threadID, participantID string) error
+	SendMessage(ctx context.Context, threadID, body string, fileIDs []string) error
+	GetUnackedMessages(ctx context.Context) ([]*threadsv1.Message, error)
+	AckMessages(ctx context.Context, messageIDs []string) error
+	Subscribe(ctx context.Context) (*connect.ServerStreamForClient[notificationsv1.SubscribeResponse], error)
+	UploadFile(ctx context.Context, metadata *filesv1.UploadFileMetadata, payload []byte) (*filesv1.FileInfo, error)
+	GetFileMetadata(ctx context.Context, fileID string) (*filesv1.FileInfo, error)
+	GetFileContent(ctx context.Context, fileID string) ([]byte, error)
+}
+
 type Service struct {
 	store           Store
-	gateway         *gateway.Client
+	gateway         Gateway
 	appID           string
 	telegramBaseURL string
 	pollTimeout     time.Duration
@@ -47,7 +65,7 @@ type ServiceConfig struct {
 	PollTimeout     time.Duration
 }
 
-func NewService(store Store, gatewayClient *gateway.Client, cfg ServiceConfig) *Service {
+func NewService(store Store, gatewayClient Gateway, cfg ServiceConfig) *Service {
 	return &Service{
 		store:           store,
 		gateway:         gatewayClient,
@@ -135,14 +153,14 @@ func (s *Service) parseInstallation(ctx context.Context, installation *appsv1.In
 
 type installationManager struct {
 	store           Store
-	gateway         *gateway.Client
+	gateway         Gateway
 	telegramBaseURL string
 	pollTimeout     time.Duration
 	mu              sync.Mutex
 	workers         map[uuid.UUID]*installationWorker
 }
 
-func newInstallationManager(store Store, gatewayClient *gateway.Client, telegramBaseURL string, pollTimeout time.Duration) *installationManager {
+func newInstallationManager(store Store, gatewayClient Gateway, telegramBaseURL string, pollTimeout time.Duration) *installationManager {
 	return &installationManager{
 		store:           store,
 		gateway:         gatewayClient,

--- a/internal/connector/worker.go
+++ b/internal/connector/worker.go
@@ -6,21 +6,20 @@ import (
 	"sync"
 	"time"
 
-	"github.com/agynio/telegram-connector/internal/gateway"
 	"github.com/agynio/telegram-connector/internal/telegram"
 )
 
 type installationWorker struct {
 	installation   Installation
 	store          Store
-	gateway        *gateway.Client
+	gateway        Gateway
 	telegramClient *telegram.Client
 	pollTimeout    time.Duration
 	cancel         context.CancelFunc
 	done           chan struct{}
 }
 
-func newInstallationWorker(installation Installation, store Store, gatewayClient *gateway.Client, telegramBaseURL string, pollTimeout time.Duration) *installationWorker {
+func newInstallationWorker(installation Installation, store Store, gatewayClient Gateway, telegramBaseURL string, pollTimeout time.Duration) *installationWorker {
 	return &installationWorker{
 		installation:   installation,
 		store:          store,

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -86,6 +86,16 @@ func (s *Store) CreateChatMapping(ctx context.Context, input ChatMappingInput) (
 	return mapping, nil
 }
 
+func (s *Store) DeleteChatMapping(ctx context.Context, installationID uuid.UUID, chatID int64) error {
+	if _, err := s.pool.Exec(ctx, `
+        DELETE FROM chat_mappings
+        WHERE installation_id = $1 AND telegram_chat_id = $2
+    `, installationID, chatID); err != nil {
+		return fmt.Errorf("delete chat mapping: %w", err)
+	}
+	return nil
+}
+
 func (s *Store) ClearChatBlocked(ctx context.Context, installationID uuid.UUID, chatID int64) error {
 	if _, err := s.pool.Exec(ctx, `
         UPDATE chat_mappings


### PR DESCRIPTION
## Summary
- detect degraded thread SendMessage errors and remap chat mappings
- recreate threads/participants on degraded errors and resend once
- add unit tests for degraded classification and remap behavior

## Testing
- buf generate buf.build/agynio/api --path agynio/api/apps/v1/apps.proto --path agynio/api/organizations/v1/organizations.proto --path agynio/api/files/v1/files.proto --path agynio/api/threads/v1/threads.proto --path agynio/api/notifications/v1/notifications.proto --path agynio/api/gateway/v1/apps.proto --path agynio/api/gateway/v1/files.proto --path agynio/api/gateway/v1/threads.proto --path agynio/api/gateway/v1/notifications.proto
- go vet ./...
- go test ./...

Refs #148