### PR TITLE
feat: add installation status reporting

### DIFF
--- a/internal/connector/audit.go
+++ b/internal/connector/audit.go
@@ -1,0 +1,93 @@
+package connector
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	appsv1 "github.com/agynio/telegram-connector/.gen/go/agynio/api/apps/v1"
+)
+
+const (
+	auditRetryDelay = time.Second
+	auditRetryMax   = 3
+)
+
+const (
+	auditEventPollingStarted       = "polling_started"
+	auditEventPollingStopped       = "polling_stopped"
+	auditEventConfigurationInvalid = "configuration_invalid"
+	auditEventBotTokenRejected     = "bot_token_rejected"
+	auditEventTelegramUnreachable  = "telegram_unreachable"
+	auditEventTelegramRecovered    = "telegram_recovered"
+	auditEventThreadDegraded       = "thread_degraded_rotated"
+	auditEventOutboundFailed       = "outbound_delivery_failed"
+	auditEventBotBlocked           = "bot_blocked_by_user"
+	auditEventBotUnblocked         = "bot_unblocked_by_user"
+)
+
+type auditEvent struct {
+	name           string
+	message        string
+	level          appsv1.InstallationAuditLogLevel
+	idempotencyKey string
+}
+
+func (w *installationWorker) appendAudit(ctx context.Context, event auditEvent) {
+	key := strings.TrimSpace(event.idempotencyKey)
+	if key == "" {
+		key = auditKey(event.name, w.installation.ID.String(), strconv.FormatInt(time.Now().UTC().Unix(), 10))
+	}
+	attempts := 0
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		err := w.gateway.AppendInstallationAuditLogEntry(ctx, w.installation.ID.String(), event.message, event.level, key)
+		if err == nil {
+			return
+		}
+		attempts++
+		if attempts >= auditRetryMax {
+			log.Printf("connector: audit %s error: %v", event.name, err)
+			if w.status != nil {
+				w.status.RecordError(time.Now().UTC(), fmt.Sprintf("audit %s: %v", event.name, err))
+			}
+			return
+		}
+		if !sleepContext(ctx, auditRetryDelay) {
+			return
+		}
+	}
+}
+
+func auditKey(event string, parts ...string) string {
+	clean := make([]string, 0, len(parts)+1)
+	clean = append(clean, event)
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed == "" {
+			continue
+		}
+		clean = append(clean, trimmed)
+	}
+	return strings.Join(clean, ":")
+}
+
+func auditKeyWithTime(event string, installationID uuid.UUID, timestamp time.Time, parts ...string) string {
+	base := []string{installationID.String(), strconv.FormatInt(timestamp.UTC().Unix(), 10)}
+	base = append(base, parts...)
+	return auditKey(event, base...)
+}
+
+func auditKeyWithHash(event string, installationID uuid.UUID, value string) string {
+	hash := sha256.Sum256([]byte(value))
+	return auditKey(event, installationID.String(), hex.EncodeToString(hash[:]))
+}

--- a/internal/connector/audit.go
+++ b/internal/connector/audit.go
@@ -43,7 +43,11 @@ type auditEvent struct {
 func (w *installationWorker) appendAudit(ctx context.Context, event auditEvent) {
 	key := strings.TrimSpace(event.idempotencyKey)
 	if key == "" {
-		key = auditKey(event.name, w.installation.ID.String(), strconv.FormatInt(time.Now().UTC().Unix(), 10))
+		log.Printf("connector: audit %s missing idempotency key", event.name)
+		if w.status != nil {
+			w.status.RecordError(time.Now().UTC(), fmt.Sprintf("audit %s missing idempotency key", event.name))
+		}
+		return
 	}
 	attempts := 0
 	for {

--- a/internal/connector/inbound.go
+++ b/internal/connector/inbound.go
@@ -5,12 +5,14 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net/http"
 	"strings"
 	"time"
 
 	"connectrpc.com/connect"
 	"github.com/google/uuid"
 
+	appsv1 "github.com/agynio/telegram-connector/.gen/go/agynio/api/apps/v1"
 	filesv1 "github.com/agynio/telegram-connector/.gen/go/agynio/api/files/v1"
 	"github.com/agynio/telegram-connector/internal/store"
 	"github.com/agynio/telegram-connector/internal/telegram"
@@ -21,11 +23,8 @@ const (
 	degradedThreadMessage = "thread is degraded"
 )
 
-func (w *installationWorker) runInbound(ctx context.Context) error {
-	lastUpdateID, err := w.loadInstallationState(ctx)
-	if err != nil {
-		return err
-	}
+func (w *installationWorker) runInbound(ctx context.Context, state store.InstallationState) error {
+	lastUpdateID := state.LastUpdateID
 	offset := lastUpdateID + 1
 
 	for {
@@ -34,15 +33,25 @@ func (w *installationWorker) runInbound(ctx context.Context) error {
 			return nil
 		default:
 		}
+		if w.status != nil && w.status.TokenRejected() {
+			<-ctx.Done()
+			return nil
+		}
 
 		updates, err := w.telegramClient.GetUpdates(ctx, offset, w.pollTimeout)
+		now := time.Now().UTC()
 		if err != nil {
 			log.Printf("connector: getUpdates error: %v", err)
+			w.handlePollError(ctx, now, err)
 			if !sleepContext(ctx, inboundRetryDelay) {
 				return nil
 			}
 			continue
 		}
+		if w.status != nil {
+			w.status.RecordPollSuccess(now, lastUpdateID)
+		}
+		w.handlePollSuccess(ctx, now)
 		if len(updates) == 0 {
 			continue
 		}
@@ -55,6 +64,9 @@ func (w *installationWorker) runInbound(ctx context.Context) error {
 			}
 			if err := w.handleUpdate(ctx, update); err != nil {
 				log.Printf("connector: handle update error: %v", err)
+				if w.status != nil {
+					w.status.RecordError(time.Now().UTC(), formatStatusError(err))
+				}
 				processingFailed = true
 				break
 			}
@@ -72,10 +84,87 @@ func (w *installationWorker) runInbound(ctx context.Context) error {
 			lastUpdateID = maxUpdateID
 			offset = lastUpdateID + 1
 		}
+		if w.status != nil {
+			w.status.RecordPollSuccess(now, lastUpdateID)
+		}
 	}
 }
 
-func (w *installationWorker) loadInstallationState(ctx context.Context) (int64, error) {
+func (w *installationWorker) handlePollError(ctx context.Context, now time.Time, err error) {
+	if w.status != nil {
+		w.status.RecordError(now, formatStatusError(err))
+	}
+	var apiErr *telegram.APIError
+	if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusUnauthorized {
+		w.handleTokenRejected(ctx, now)
+		return
+	}
+	if w.status != nil {
+		if w.status.SetPollingDegraded(true) {
+			w.status.Report(ctx)
+		}
+	}
+	if w.telegramFailureAt.IsZero() {
+		w.telegramFailureAt = now
+	}
+	if !w.telegramUnreachable && now.Sub(w.telegramFailureAt) >= telegramUnreachableTimeout {
+		w.telegramUnreachable = true
+		w.appendAudit(ctx, auditEvent{
+			name:           auditEventTelegramUnreachable,
+			message:        fmt.Sprintf("%s: getUpdates failing since %s", auditEventTelegramUnreachable, formatTimestamp(w.telegramFailureAt)),
+			level:          appsv1.InstallationAuditLogLevel_INSTALLATION_AUDIT_LOG_LEVEL_WARNING,
+			idempotencyKey: auditKeyWithTime(auditEventTelegramUnreachable, w.installation.ID, w.telegramFailureAt),
+		})
+	}
+}
+
+func (w *installationWorker) handlePollSuccess(ctx context.Context, now time.Time) {
+	wasUnreachable := w.telegramUnreachable
+	wasRejected := false
+	stateChanged := false
+	if w.status != nil {
+		wasRejected = w.status.TokenRejected()
+		if w.status.SetTokenRejected(false) {
+			stateChanged = true
+		}
+		if w.status.SetPollingDegraded(false) {
+			stateChanged = true
+		}
+	}
+	if wasUnreachable || wasRejected {
+		w.appendAudit(ctx, auditEvent{
+			name:           auditEventTelegramRecovered,
+			message:        fmt.Sprintf("%s: getUpdates recovered at %s", auditEventTelegramRecovered, formatTimestamp(now)),
+			level:          appsv1.InstallationAuditLogLevel_INSTALLATION_AUDIT_LOG_LEVEL_INFO,
+			idempotencyKey: auditKeyWithTime(auditEventTelegramRecovered, w.installation.ID, now),
+		})
+	}
+	w.telegramFailureAt = time.Time{}
+	w.telegramUnreachable = false
+	if stateChanged && w.status != nil {
+		w.status.Report(ctx)
+	}
+}
+
+func (w *installationWorker) handleTokenRejected(ctx context.Context, now time.Time) {
+	wasRejected := false
+	if w.status != nil {
+		wasRejected = w.status.TokenRejected()
+		if w.status.SetTokenRejected(true) {
+			w.status.Report(ctx)
+		}
+	}
+	if !wasRejected {
+		w.appendAudit(ctx, auditEvent{
+			name:           auditEventBotTokenRejected,
+			message:        fmt.Sprintf("%s: telegram returned 401 Unauthorized", auditEventBotTokenRejected),
+			level:          appsv1.InstallationAuditLogLevel_INSTALLATION_AUDIT_LOG_LEVEL_ERROR,
+			idempotencyKey: auditKeyWithTime(auditEventBotTokenRejected, w.installation.ID, now),
+		})
+	}
+}
+
+func (w *installationWorker) loadInstallationState(ctx context.Context) (store.InstallationState, error) {
 	for {
 		state, err := w.store.GetInstallationState(ctx, w.installation.ID)
 		if err == nil {
@@ -83,7 +172,7 @@ func (w *installationWorker) loadInstallationState(ctx context.Context) (int64, 
 		}
 		log.Printf("connector: get installation state error: %v", err)
 		if !sleepContext(ctx, inboundRetryDelay) {
-			return 0, ctx.Err()
+			return store.InstallationState{}, ctx.Err()
 		}
 	}
 }
@@ -118,8 +207,17 @@ func (w *installationWorker) handleUpdate(ctx context.Context, update telegram.U
 		return err
 	}
 	if found && mapping.BlockedAt != nil {
-		if err := w.store.ClearChatBlocked(ctx, w.installation.ID, message.Chat.ID); err != nil {
+		cleared, err := w.store.ClearChatBlocked(ctx, w.installation.ID, message.Chat.ID)
+		if err != nil {
 			return err
+		}
+		if cleared {
+			w.appendAudit(ctx, auditEvent{
+				name:           auditEventBotUnblocked,
+				message:        fmt.Sprintf("%s: chat_id=%d", auditEventBotUnblocked, message.Chat.ID),
+				level:          appsv1.InstallationAuditLogLevel_INSTALLATION_AUDIT_LOG_LEVEL_INFO,
+				idempotencyKey: auditKeyWithTime(auditEventBotUnblocked, w.installation.ID, time.Now().UTC(), fmt.Sprintf("chat-%d", message.Chat.ID)),
+			})
 		}
 	}
 	if !found {
@@ -139,19 +237,35 @@ func (w *installationWorker) handleUpdate(ctx context.Context, update telegram.U
 		if !isThreadDegradedError(err) {
 			return err
 		}
+		if w.status != nil {
+			w.status.RecordError(time.Now().UTC(), formatStatusError(err))
+		}
 		log.Printf("connector: thread %s degraded for chat %d", threadID.String(), message.Chat.ID)
+		oldThreadID := threadID
 		mapping, err = w.remapThreadMapping(ctx, message)
 		if err != nil {
 			return err
 		}
 		threadID = mapping.ThreadID
+		w.appendAudit(ctx, auditEvent{
+			name:           auditEventThreadDegraded,
+			message:        fmt.Sprintf("%s: chat_id=%d old_thread_id=%s new_thread_id=%s", auditEventThreadDegraded, message.Chat.ID, oldThreadID.String(), threadID.String()),
+			level:          appsv1.InstallationAuditLogLevel_INSTALLATION_AUDIT_LOG_LEVEL_WARNING,
+			idempotencyKey: auditKey(auditEventThreadDegraded, w.installation.ID.String(), oldThreadID.String(), threadID.String(), fmt.Sprintf("chat-%d", message.Chat.ID)),
+		})
 		if err := w.gateway.SendMessage(ctx, threadID.String(), body, fileIDs); err != nil {
 			if isThreadDegradedError(err) {
 				log.Printf("connector: remapped thread %s degraded for chat %d", threadID.String(), message.Chat.ID)
+				if w.status != nil {
+					w.status.RecordError(time.Now().UTC(), formatStatusError(err))
+				}
 				return nil
 			}
 			return err
 		}
+	}
+	if w.status != nil {
+		w.status.RecordInbound(time.Now().UTC())
 	}
 	return nil
 }

--- a/internal/connector/inbound.go
+++ b/internal/connector/inbound.go
@@ -120,10 +120,8 @@ func (w *installationWorker) handlePollError(ctx context.Context, now time.Time,
 
 func (w *installationWorker) handlePollSuccess(ctx context.Context, now time.Time) {
 	wasUnreachable := w.telegramUnreachable
-	wasRejected := false
 	stateChanged := false
 	if w.status != nil {
-		wasRejected = w.status.TokenRejected()
 		if w.status.SetTokenRejected(false) {
 			stateChanged = true
 		}
@@ -131,7 +129,7 @@ func (w *installationWorker) handlePollSuccess(ctx context.Context, now time.Tim
 			stateChanged = true
 		}
 	}
-	if wasUnreachable || wasRejected {
+	if wasUnreachable {
 		w.appendAudit(ctx, auditEvent{
 			name:           auditEventTelegramRecovered,
 			message:        fmt.Sprintf("%s: getUpdates recovered at %s", auditEventTelegramRecovered, formatTimestamp(now)),

--- a/internal/connector/inbound_test.go
+++ b/internal/connector/inbound_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -24,6 +25,8 @@ type stubGateway struct {
 	createThreadFn   func(context.Context, string) (*threadsv1.Thread, error)
 	addParticipantFn func(context.Context, string, string, string) error
 	sendMessageFn    func(context.Context, string, string, []string) error
+	reportStatusFn   func(context.Context, string, string) error
+	appendAuditFn    func(context.Context, string, string, appsv1.InstallationAuditLogLevel, string) error
 }
 
 func (s *stubGateway) AppIdentityID() string {
@@ -86,14 +89,30 @@ func (s *stubGateway) GetFileContent(ctx context.Context, fileID string) ([]byte
 	return nil, nil
 }
 
+func (s *stubGateway) ReportInstallationStatus(ctx context.Context, installationID, status string) error {
+	if s.reportStatusFn == nil {
+		s.t.Fatalf("unexpected ReportInstallationStatus")
+	}
+	return s.reportStatusFn(ctx, installationID, status)
+}
+
+func (s *stubGateway) AppendInstallationAuditLogEntry(ctx context.Context, installationID, message string, level appsv1.InstallationAuditLogLevel, idempotencyKey string) error {
+	if s.appendAuditFn == nil {
+		s.t.Fatalf("unexpected AppendInstallationAuditLogEntry")
+	}
+	return s.appendAuditFn(ctx, installationID, message, level, idempotencyKey)
+}
+
 type stubStore struct {
 	t                      *testing.T
 	getChatMappingFn       func(context.Context, uuid.UUID, int64) (store.ChatMapping, bool, error)
 	createChatMappingFn    func(context.Context, store.ChatMappingInput) (store.ChatMapping, error)
 	deleteChatMappingFn    func(context.Context, uuid.UUID, int64) error
-	clearChatBlockedFn     func(context.Context, uuid.UUID, int64) error
-	markChatBlockedFn      func(context.Context, uuid.UUID, int64) error
-	getInstallationStateFn func(context.Context, uuid.UUID) (int64, error)
+	clearChatBlockedFn     func(context.Context, uuid.UUID, int64) (bool, error)
+	markChatBlockedFn      func(context.Context, uuid.UUID, int64) (bool, error)
+	countActiveChatsFn     func(context.Context, uuid.UUID) (int64, error)
+	countBlockedChatsFn    func(context.Context, uuid.UUID) (int64, error)
+	getInstallationStateFn func(context.Context, uuid.UUID) (store.InstallationState, error)
 	upsertStateFn          func(context.Context, uuid.UUID, int64) error
 }
 
@@ -123,21 +142,35 @@ func (s *stubStore) DeleteChatMapping(ctx context.Context, installationID uuid.U
 	return s.deleteChatMappingFn(ctx, installationID, chatID)
 }
 
-func (s *stubStore) ClearChatBlocked(ctx context.Context, installationID uuid.UUID, chatID int64) error {
+func (s *stubStore) ClearChatBlocked(ctx context.Context, installationID uuid.UUID, chatID int64) (bool, error) {
 	if s.clearChatBlockedFn == nil {
 		s.t.Fatalf("unexpected ClearChatBlocked")
 	}
 	return s.clearChatBlockedFn(ctx, installationID, chatID)
 }
 
-func (s *stubStore) MarkChatBlocked(ctx context.Context, installationID uuid.UUID, chatID int64) error {
+func (s *stubStore) MarkChatBlocked(ctx context.Context, installationID uuid.UUID, chatID int64) (bool, error) {
 	if s.markChatBlockedFn == nil {
 		s.t.Fatalf("unexpected MarkChatBlocked")
 	}
 	return s.markChatBlockedFn(ctx, installationID, chatID)
 }
 
-func (s *stubStore) GetInstallationState(ctx context.Context, installationID uuid.UUID) (int64, error) {
+func (s *stubStore) CountActiveChats(ctx context.Context, installationID uuid.UUID) (int64, error) {
+	if s.countActiveChatsFn == nil {
+		s.t.Fatalf("unexpected CountActiveChats")
+	}
+	return s.countActiveChatsFn(ctx, installationID)
+}
+
+func (s *stubStore) CountBlockedChats(ctx context.Context, installationID uuid.UUID) (int64, error) {
+	if s.countBlockedChatsFn == nil {
+		s.t.Fatalf("unexpected CountBlockedChats")
+	}
+	return s.countBlockedChatsFn(ctx, installationID)
+}
+
+func (s *stubStore) GetInstallationState(ctx context.Context, installationID uuid.UUID) (store.InstallationState, error) {
 	if s.getInstallationStateFn == nil {
 		s.t.Fatalf("unexpected GetInstallationState")
 	}
@@ -177,6 +210,7 @@ func TestHandleUpdateRemapsOnDegradedThread(t *testing.T) {
 	sendCalls := make([]string, 0, 2)
 	addParticipantCalled := false
 	createThreadCalled := false
+	auditCalls := 0
 
 	storeStub := &stubStore{
 		t: t,
@@ -226,17 +260,17 @@ func TestHandleUpdateRemapsOnDegradedThread(t *testing.T) {
 				CreatedAt:      time.Now().UTC(),
 			}, nil
 		},
-		clearChatBlockedFn: func(context.Context, uuid.UUID, int64) error {
+		clearChatBlockedFn: func(context.Context, uuid.UUID, int64) (bool, error) {
 			t.Fatal("unexpected ClearChatBlocked")
-			return nil
+			return false, nil
 		},
-		markChatBlockedFn: func(context.Context, uuid.UUID, int64) error {
+		markChatBlockedFn: func(context.Context, uuid.UUID, int64) (bool, error) {
 			t.Fatal("unexpected MarkChatBlocked")
-			return nil
+			return false, nil
 		},
-		getInstallationStateFn: func(context.Context, uuid.UUID) (int64, error) {
+		getInstallationStateFn: func(context.Context, uuid.UUID) (store.InstallationState, error) {
 			t.Fatal("unexpected GetInstallationState")
-			return 0, nil
+			return store.InstallationState{}, nil
 		},
 		upsertStateFn: func(context.Context, uuid.UUID, int64) error {
 			t.Fatal("unexpected UpsertInstallationState")
@@ -276,6 +310,25 @@ func TestHandleUpdateRemapsOnDegradedThread(t *testing.T) {
 			}
 			return fmt.Errorf("unexpected thread %s", threadArg)
 		},
+		appendAuditFn: func(_ context.Context, installationArg, message string, level appsv1.InstallationAuditLogLevel, idempotencyKey string) error {
+			auditCalls++
+			if installationArg != installationID.String() {
+				t.Fatalf("expected installation %s, got %s", installationID, installationArg)
+			}
+			if level != appsv1.InstallationAuditLogLevel_INSTALLATION_AUDIT_LOG_LEVEL_WARNING {
+				t.Fatalf("expected warning level, got %v", level)
+			}
+			if !strings.Contains(message, auditEventThreadDegraded) {
+				t.Fatalf("expected audit message to include %s, got %s", auditEventThreadDegraded, message)
+			}
+			if !strings.Contains(message, oldThreadID.String()) || !strings.Contains(message, newThreadID.String()) {
+				t.Fatalf("expected audit message to include thread ids, got %s", message)
+			}
+			if strings.TrimSpace(idempotencyKey) == "" {
+				t.Fatal("expected idempotency key")
+			}
+			return nil
+		},
 	}
 
 	worker := newInstallationWorker(Installation{
@@ -312,6 +365,9 @@ func TestHandleUpdateRemapsOnDegradedThread(t *testing.T) {
 	if sendCalls[0] != oldThreadID.String() || sendCalls[1] != newThreadID.String() {
 		t.Fatalf("expected send to old then new thread, got %v", sendCalls)
 	}
+	if auditCalls != 1 {
+		t.Fatalf("expected 1 audit call, got %d", auditCalls)
+	}
 }
 
 func TestHandleUpdateStopsAfterSecondDegradedSend(t *testing.T) {
@@ -340,16 +396,16 @@ func TestHandleUpdateStopsAfterSecondDegradedSend(t *testing.T) {
 		createChatMappingFn: func(context.Context, store.ChatMappingInput) (store.ChatMapping, error) {
 			return store.ChatMapping{ThreadID: newThreadID}, nil
 		},
-		clearChatBlockedFn: func(context.Context, uuid.UUID, int64) error {
-			return nil
+		clearChatBlockedFn: func(context.Context, uuid.UUID, int64) (bool, error) {
+			return false, nil
 		},
-		markChatBlockedFn: func(context.Context, uuid.UUID, int64) error {
+		markChatBlockedFn: func(context.Context, uuid.UUID, int64) (bool, error) {
 			t.Fatal("unexpected MarkChatBlocked")
-			return nil
+			return false, nil
 		},
-		getInstallationStateFn: func(context.Context, uuid.UUID) (int64, error) {
+		getInstallationStateFn: func(context.Context, uuid.UUID) (store.InstallationState, error) {
 			t.Fatal("unexpected GetInstallationState")
-			return 0, nil
+			return store.InstallationState{}, nil
 		},
 		upsertStateFn: func(context.Context, uuid.UUID, int64) error {
 			t.Fatal("unexpected UpsertInstallationState")
@@ -367,6 +423,9 @@ func TestHandleUpdateStopsAfterSecondDegradedSend(t *testing.T) {
 		},
 		sendMessageFn: func(context.Context, string, string, []string) error {
 			return degradedErr
+		},
+		appendAuditFn: func(context.Context, string, string, appsv1.InstallationAuditLogLevel, string) error {
+			return nil
 		},
 	}
 

--- a/internal/connector/installation_config.go
+++ b/internal/connector/installation_config.go
@@ -8,6 +8,15 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
+type installationConfigError struct {
+	installationID uuid.UUID
+	message        string
+}
+
+func (e *installationConfigError) Error() string {
+	return e.message
+}
+
 func parseInstallationConfig(config *structpb.Struct) (string, uuid.UUID, error) {
 	if config == nil {
 		return "", uuid.Nil, fmt.Errorf("installation configuration is missing")

--- a/internal/connector/outbound.go
+++ b/internal/connector/outbound.go
@@ -5,11 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net/http"
 	"strings"
 	"time"
 
 	"github.com/google/uuid"
 
+	appsv1 "github.com/agynio/telegram-connector/.gen/go/agynio/api/apps/v1"
 	filesv1 "github.com/agynio/telegram-connector/.gen/go/agynio/api/files/v1"
 	threadsv1 "github.com/agynio/telegram-connector/.gen/go/agynio/api/threads/v1"
 	"github.com/agynio/telegram-connector/internal/store"
@@ -74,12 +76,18 @@ func (w *installationWorker) subscribeNotifications(ctx context.Context, trigger
 }
 
 func (w *installationWorker) processOutbound(ctx context.Context) {
+	if w.status != nil && w.status.TokenRejected() {
+		return
+	}
 	messages, err := w.gateway.GetUnackedMessages(ctx)
 	if err != nil {
 		log.Printf("connector: get unacked messages error: %v", err)
 		return
 	}
 	for _, message := range messages {
+		if w.status != nil && w.status.TokenRejected() {
+			return
+		}
 		shouldAck := false
 		if message.GetSenderId() == w.gateway.AppIdentityID() {
 			shouldAck = true
@@ -103,8 +111,17 @@ func (w *installationWorker) processOutbound(ctx context.Context) {
 				} else {
 					blocked, err := w.deliverOutboundMessage(ctx, mapping, message)
 					if blocked {
-						if err := w.store.MarkChatBlocked(ctx, w.installation.ID, mapping.TelegramChatID); err != nil {
-							log.Printf("connector: mark chat blocked error: %v", err)
+						marked, markErr := w.store.MarkChatBlocked(ctx, w.installation.ID, mapping.TelegramChatID)
+						if markErr != nil {
+							log.Printf("connector: mark chat blocked error: %v", markErr)
+						}
+						if marked {
+							w.appendAudit(ctx, auditEvent{
+								name:           auditEventBotBlocked,
+								message:        fmt.Sprintf("%s: chat_id=%d", auditEventBotBlocked, mapping.TelegramChatID),
+								level:          appsv1.InstallationAuditLogLevel_INSTALLATION_AUDIT_LOG_LEVEL_INFO,
+								idempotencyKey: auditKeyWithTime(auditEventBotBlocked, w.installation.ID, time.Now().UTC(), fmt.Sprintf("chat-%d", mapping.TelegramChatID)),
+							})
 						}
 						shouldAck = true
 					}
@@ -113,6 +130,7 @@ func (w *installationWorker) processOutbound(ctx context.Context) {
 							return
 						}
 						log.Printf("connector: deliver outbound error: %v", err)
+						w.logOutboundFailure(ctx, message, err)
 						shouldAck = true
 					} else {
 						shouldAck = true
@@ -219,6 +237,37 @@ func (w *installationWorker) fetchGatewayFile(ctx context.Context, fileID string
 	}
 }
 
+func (w *installationWorker) logOutboundFailure(ctx context.Context, message *threadsv1.Message, err error) {
+	if message == nil {
+		return
+	}
+	if w.status != nil && w.status.TokenRejected() {
+		var apiErr *telegram.APIError
+		if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusUnauthorized {
+			return
+		}
+	}
+	if w.status != nil {
+		if w.status.SetOutboundDegraded(true) {
+			w.status.Report(ctx)
+		}
+	}
+	detail := formatStatusError(err)
+	if detail == "" {
+		detail = "unknown"
+	}
+	key := auditKey(auditEventOutboundFailed, w.installation.ID.String(), message.GetId())
+	if message.GetId() == "" {
+		key = auditKeyWithTime(auditEventOutboundFailed, w.installation.ID, time.Now().UTC(), message.GetThreadId())
+	}
+	w.appendAudit(ctx, auditEvent{
+		name:           auditEventOutboundFailed,
+		message:        fmt.Sprintf("%s: thread_id=%s message_id=%s error=%s", auditEventOutboundFailed, message.GetThreadId(), message.GetId(), detail),
+		level:          appsv1.InstallationAuditLogLevel_INSTALLATION_AUDIT_LOG_LEVEL_ERROR,
+		idempotencyKey: key,
+	})
+}
+
 func (w *installationWorker) sendWithRetry(ctx context.Context, send func(context.Context) error) (bool, error) {
 	rateBackoff := outboundRetryBase
 	attempts := 0
@@ -228,11 +277,29 @@ func (w *installationWorker) sendWithRetry(ctx context.Context, send func(contex
 		}
 		err := send(ctx)
 		if err == nil {
+			if w.status != nil {
+				now := time.Now().UTC()
+				w.status.RecordOutbound(now)
+				if w.status.SetOutboundDegraded(false) {
+					w.status.Report(ctx)
+				}
+			}
 			return false, nil
 		}
 		var apiErr *telegram.APIError
 		if errors.As(err, &apiErr) {
+			if apiErr.StatusCode == http.StatusUnauthorized {
+				now := time.Now().UTC()
+				if w.status != nil {
+					w.status.RecordError(now, formatStatusError(err))
+				}
+				w.handleTokenRejected(ctx, now)
+				return false, err
+			}
 			if apiErr.IsBlocked() {
+				if w.status != nil {
+					w.status.RecordError(time.Now().UTC(), formatStatusError(err))
+				}
 				return true, err
 			}
 			if apiErr.IsRateLimit() {
@@ -256,10 +323,16 @@ func (w *installationWorker) sendWithRetry(ctx context.Context, send func(contex
 				}
 				continue
 			}
+			if w.status != nil {
+				w.status.RecordError(time.Now().UTC(), formatStatusError(err))
+			}
 			return false, err
 		}
 		attempts++
 		if attempts > outboundRetryMax {
+			if w.status != nil {
+				w.status.RecordError(time.Now().UTC(), formatStatusError(err))
+			}
 			return false, err
 		}
 		if !sleepContext(ctx, retryDelay(attempts)) {

--- a/internal/connector/outbound.go
+++ b/internal/connector/outbound.go
@@ -253,16 +253,25 @@ func (w *installationWorker) logOutboundFailure(ctx context.Context, message *th
 		}
 	}
 	detail := formatStatusError(err)
-	if detail == "" {
-		detail = "unknown"
+	if strings.TrimSpace(detail) == "" {
+		log.Printf("connector: outbound failure missing error detail for message %s", message.GetId())
+		if w.status != nil {
+			w.status.RecordError(time.Now().UTC(), "outbound failure missing error detail")
+		}
+		return
 	}
-	key := auditKey(auditEventOutboundFailed, w.installation.ID.String(), message.GetId())
-	if message.GetId() == "" {
-		key = auditKeyWithTime(auditEventOutboundFailed, w.installation.ID, time.Now().UTC(), message.GetThreadId())
+	messageID := strings.TrimSpace(message.GetId())
+	if messageID == "" {
+		log.Printf("connector: outbound failure missing message id for thread %s", message.GetThreadId())
+		if w.status != nil {
+			w.status.RecordError(time.Now().UTC(), "outbound failure missing message id")
+		}
+		return
 	}
+	key := auditKey(auditEventOutboundFailed, w.installation.ID.String(), messageID)
 	w.appendAudit(ctx, auditEvent{
 		name:           auditEventOutboundFailed,
-		message:        fmt.Sprintf("%s: thread_id=%s message_id=%s error=%s", auditEventOutboundFailed, message.GetThreadId(), message.GetId(), detail),
+		message:        fmt.Sprintf("%s: thread_id=%s message_id=%s error=%s", auditEventOutboundFailed, message.GetThreadId(), messageID, detail),
 		level:          appsv1.InstallationAuditLogLevel_INSTALLATION_AUDIT_LOG_LEVEL_ERROR,
 		idempotencyKey: key,
 	})

--- a/internal/connector/service.go
+++ b/internal/connector/service.go
@@ -82,11 +82,11 @@ func NewService(store Store, gatewayClient Gateway, cfg ServiceConfig) *Service 
 
 func (s *Service) Run(ctx context.Context) error {
 	manager := newInstallationManager(s.store, s.gateway, s.telegramBaseURL, s.pollTimeout)
-	installations, err := s.listInstallations(ctx)
+	installations, misconfigured, err := s.listInstallations(ctx)
 	if err != nil {
 		return err
 	}
-	manager.Sync(ctx, installations)
+	manager.Sync(ctx, installations, misconfigured)
 
 	ticker := time.NewTicker(reconcileInterval)
 	defer ticker.Stop()
@@ -97,28 +97,30 @@ func (s *Service) Run(ctx context.Context) error {
 			manager.StopAll()
 			return nil
 		case <-ticker.C:
-			installations, err := s.listInstallations(ctx)
+			installations, misconfigured, err := s.listInstallations(ctx)
 			if err != nil {
 				log.Printf("connector: reconcile installations error: %v", err)
 				continue
 			}
-			manager.Sync(ctx, installations)
+			manager.Sync(ctx, installations, misconfigured)
 		}
 	}
 }
 
-func (s *Service) listInstallations(ctx context.Context) ([]Installation, error) {
+func (s *Service) listInstallations(ctx context.Context) ([]Installation, map[uuid.UUID]struct{}, error) {
 	installations, err := s.gateway.ListInstallations(ctx, s.appID)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	resolved := make([]Installation, 0, len(installations))
+	misconfigured := make(map[uuid.UUID]struct{})
 	for _, installation := range installations {
 		parsed, err := s.parseInstallation(ctx, installation)
 		if err != nil {
 			var configErr *installationConfigError
 			if errors.As(err, &configErr) {
 				s.reportConfigurationInvalid(ctx, configErr.installationID, configErr.message)
+				misconfigured[configErr.installationID] = struct{}{}
 				continue
 			}
 			installationID := ""
@@ -134,7 +136,7 @@ func (s *Service) listInstallations(ctx context.Context) ([]Installation, error)
 		}
 		resolved = append(resolved, parsed)
 	}
-	return resolved, nil
+	return resolved, misconfigured, nil
 }
 
 func (s *Service) parseInstallation(ctx context.Context, installation *appsv1.Installation) (Installation, error) {
@@ -221,7 +223,7 @@ func newInstallationManager(store Store, gatewayClient Gateway, telegramBaseURL 
 	}
 }
 
-func (m *installationManager) Sync(ctx context.Context, installations []Installation) {
+func (m *installationManager) Sync(ctx context.Context, installations []Installation, misconfigured map[uuid.UUID]struct{}) {
 	desired := make(map[uuid.UUID]Installation, len(installations))
 	for _, installation := range installations {
 		desired[installation.ID] = installation
@@ -231,10 +233,16 @@ func (m *installationManager) Sync(ctx context.Context, installations []Installa
 	defer m.mu.Unlock()
 
 	for id, worker := range m.workers {
-		if _, ok := desired[id]; !ok {
-			worker.Stop(stopReasonRemoved)
-			delete(m.workers, id)
+		if _, ok := desired[id]; ok {
+			continue
 		}
+		if _, ok := misconfigured[id]; ok {
+			worker.Stop(stopReasonMisconfigured)
+			delete(m.workers, id)
+			continue
+		}
+		worker.Stop(stopReasonRemoved)
+		delete(m.workers, id)
 	}
 
 	for id, installation := range desired {

--- a/internal/connector/service.go
+++ b/internal/connector/service.go
@@ -2,6 +2,7 @@ package connector
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"sync"
@@ -24,9 +25,11 @@ type Store interface {
 	GetChatMappingByThreadID(ctx context.Context, installationID, threadID uuid.UUID) (store.ChatMapping, bool, error)
 	CreateChatMapping(ctx context.Context, input store.ChatMappingInput) (store.ChatMapping, error)
 	DeleteChatMapping(ctx context.Context, installationID uuid.UUID, chatID int64) error
-	ClearChatBlocked(ctx context.Context, installationID uuid.UUID, chatID int64) error
-	MarkChatBlocked(ctx context.Context, installationID uuid.UUID, chatID int64) error
-	GetInstallationState(ctx context.Context, installationID uuid.UUID) (int64, error)
+	ClearChatBlocked(ctx context.Context, installationID uuid.UUID, chatID int64) (bool, error)
+	MarkChatBlocked(ctx context.Context, installationID uuid.UUID, chatID int64) (bool, error)
+	CountActiveChats(ctx context.Context, installationID uuid.UUID) (int64, error)
+	CountBlockedChats(ctx context.Context, installationID uuid.UUID) (int64, error)
+	GetInstallationState(ctx context.Context, installationID uuid.UUID) (store.InstallationState, error)
 	UpsertInstallationState(ctx context.Context, installationID uuid.UUID, lastUpdateID int64) error
 }
 
@@ -42,6 +45,8 @@ type Gateway interface {
 	UploadFile(ctx context.Context, metadata *filesv1.UploadFileMetadata, payload []byte) (*filesv1.FileInfo, error)
 	GetFileMetadata(ctx context.Context, fileID string) (*filesv1.FileInfo, error)
 	GetFileContent(ctx context.Context, fileID string) ([]byte, error)
+	ReportInstallationStatus(ctx context.Context, installationID, status string) error
+	AppendInstallationAuditLogEntry(ctx context.Context, installationID, message string, level appsv1.InstallationAuditLogLevel, idempotencyKey string) error
 }
 
 type Service struct {
@@ -111,6 +116,11 @@ func (s *Service) listInstallations(ctx context.Context) ([]Installation, error)
 	for _, installation := range installations {
 		parsed, err := s.parseInstallation(ctx, installation)
 		if err != nil {
+			var configErr *installationConfigError
+			if errors.As(err, &configErr) {
+				s.reportConfigurationInvalid(ctx, configErr.installationID, configErr.message)
+				continue
+			}
 			installationID := ""
 			appID := ""
 			if installation != nil {
@@ -141,7 +151,7 @@ func (s *Service) parseInstallation(ctx context.Context, installation *appsv1.In
 	}
 	botToken, agentID, err := parseInstallationConfig(installation.GetConfiguration())
 	if err != nil {
-		return Installation{}, err
+		return Installation{}, &installationConfigError{installationID: installationID, message: err.Error()}
 	}
 	return Installation{
 		ID:             installationID,
@@ -149,6 +159,47 @@ func (s *Service) parseInstallation(ctx context.Context, installation *appsv1.In
 		BotToken:       botToken,
 		AgentID:        agentID,
 	}, nil
+}
+
+func (s *Service) reportConfigurationInvalid(ctx context.Context, installationID uuid.UUID, message string) {
+	now := time.Now().UTC()
+	state, err := s.store.GetInstallationState(ctx, installationID)
+	if err != nil {
+		log.Printf("connector: get installation state for %s error: %v", installationID, err)
+	}
+	lastUpdateAt := state.UpdatedAt
+	if lastUpdateAt.IsZero() {
+		lastUpdateAt = now
+	}
+	activeChats, err := s.store.CountActiveChats(ctx, installationID)
+	if err != nil {
+		log.Printf("connector: count active chats for %s error: %v", installationID, err)
+		activeChats = 0
+	}
+	blockedChats, err := s.store.CountBlockedChats(ctx, installationID)
+	if err != nil {
+		log.Printf("connector: count blocked chats for %s error: %v", installationID, err)
+		blockedChats = 0
+	}
+	status := buildStatus(statusMetrics{
+		State:              statusMisconfigured,
+		StartAt:            now,
+		LastUpdateAt:       lastUpdateAt,
+		LastUpdateID:       state.LastUpdateID,
+		ActiveChats:        activeChats,
+		BlockedChats:       blockedChats,
+		InboundMessages1h:  0,
+		OutboundMessages1h: 0,
+		LastOutboundAt:     lastUpdateAt,
+		LastError:          &statusError{message: message, at: now},
+	})
+	if err := s.gateway.ReportInstallationStatus(ctx, installationID.String(), status); err != nil {
+		log.Printf("connector: report status for %s error: %v", installationID, err)
+	}
+	auditMessage := fmt.Sprintf("%s: %s", auditEventConfigurationInvalid, message)
+	if err := s.gateway.AppendInstallationAuditLogEntry(ctx, installationID.String(), auditMessage, appsv1.InstallationAuditLogLevel_INSTALLATION_AUDIT_LOG_LEVEL_ERROR, auditKeyWithHash(auditEventConfigurationInvalid, installationID, message)); err != nil {
+		log.Printf("connector: append audit log for %s error: %v", installationID, err)
+	}
 }
 
 type installationManager struct {
@@ -181,7 +232,7 @@ func (m *installationManager) Sync(ctx context.Context, installations []Installa
 
 	for id, worker := range m.workers {
 		if _, ok := desired[id]; !ok {
-			worker.Stop()
+			worker.Stop(stopReasonRemoved)
 			delete(m.workers, id)
 		}
 	}
@@ -192,7 +243,7 @@ func (m *installationManager) Sync(ctx context.Context, installations []Installa
 			continue
 		}
 		if ok {
-			worker.Stop()
+			worker.Stop(stopReasonShutdown)
 			delete(m.workers, id)
 		}
 		newWorker := newInstallationWorker(installation, m.store, m.gateway, m.telegramBaseURL, m.pollTimeout)
@@ -211,7 +262,7 @@ func (m *installationManager) StopAll() {
 	m.mu.Unlock()
 
 	for _, worker := range workers {
-		worker.Stop()
+		worker.Stop(stopReasonShutdown)
 	}
 }
 

--- a/internal/connector/status.go
+++ b/internal/connector/status.go
@@ -213,7 +213,6 @@ func (s *installationStatus) Report(ctx context.Context) {
 	defer s.reportMu.Unlock()
 
 	now := time.Now().UTC()
-	snapshot := s.snapshot(now)
 	activeChats, err := s.store.CountActiveChats(ctx, s.installationID)
 	if err != nil {
 		log.Printf("connector: count active chats error: %v", err)
@@ -226,6 +225,7 @@ func (s *installationStatus) Report(ctx context.Context) {
 		s.RecordError(now, fmt.Sprintf("count blocked chats: %v", err))
 		blockedChats = 0
 	}
+	snapshot := s.snapshot(now)
 	status := buildStatus(statusMetrics{
 		State:              snapshot.state,
 		StartAt:            snapshot.startAt,
@@ -281,8 +281,9 @@ func (s *installationStatus) updateStateLocked() bool {
 }
 
 func buildStatus(metrics statusMetrics) string {
-	headline := fmt.Sprintf("**%s** — polling since %s", metrics.State, formatTimestamp(metrics.StartAt))
+	headline := string(metrics.State)
 	lines := []string{
+		fmt.Sprintf("- status_since: %s", formatTimestamp(metrics.StartAt)),
 		fmt.Sprintf("- last_update_at: %s", formatTimestamp(metrics.LastUpdateAt)),
 		fmt.Sprintf("- last_update_id: %d", metrics.LastUpdateID),
 		fmt.Sprintf("- active_chats: %d", metrics.ActiveChats),

--- a/internal/connector/status.go
+++ b/internal/connector/status.go
@@ -1,0 +1,328 @@
+package connector
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"strings"
+	"sync"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/google/uuid"
+
+	"github.com/agynio/telegram-connector/internal/store"
+	"github.com/agynio/telegram-connector/internal/telegram"
+)
+
+const (
+	statusReportInterval       = 60 * time.Second
+	statusWindow               = time.Hour
+	telegramUnreachableTimeout = 60 * time.Second
+)
+
+type statusState string
+
+const (
+	statusHealthy       statusState = "Healthy"
+	statusDegraded      statusState = "Degraded"
+	statusMisconfigured statusState = "Misconfigured"
+	statusStopped       statusState = "Stopped"
+)
+
+type statusError struct {
+	message string
+	at      time.Time
+}
+
+type rollingCounter struct {
+	entries []time.Time
+}
+
+func (r *rollingCounter) add(ts time.Time) {
+	r.entries = append(r.entries, ts)
+	r.prune(ts)
+}
+
+func (r *rollingCounter) count(now time.Time) int {
+	r.prune(now)
+	return len(r.entries)
+}
+
+func (r *rollingCounter) prune(now time.Time) {
+	cutoff := now.Add(-statusWindow)
+	idx := 0
+	for idx < len(r.entries) {
+		if r.entries[idx].After(cutoff) {
+			break
+		}
+		idx++
+	}
+	if idx > 0 {
+		r.entries = append([]time.Time(nil), r.entries[idx:]...)
+	}
+}
+
+type statusMetrics struct {
+	State              statusState
+	StartAt            time.Time
+	LastUpdateAt       time.Time
+	LastUpdateID       int64
+	ActiveChats        int64
+	BlockedChats       int64
+	InboundMessages1h  int
+	OutboundMessages1h int
+	LastOutboundAt     time.Time
+	LastError          *statusError
+}
+
+type statusSnapshot struct {
+	state              statusState
+	startAt            time.Time
+	lastUpdateAt       time.Time
+	lastUpdateID       int64
+	inboundMessages1h  int
+	outboundMessages1h int
+	lastOutboundAt     time.Time
+	lastError          *statusError
+}
+
+type installationStatus struct {
+	installationID   uuid.UUID
+	store            Store
+	gateway          Gateway
+	startAt          time.Time
+	mu               sync.Mutex
+	reportMu         sync.Mutex
+	state            statusState
+	lastUpdateAt     time.Time
+	lastUpdateID     int64
+	lastOutboundAt   time.Time
+	inboundMessages  rollingCounter
+	outboundMessages rollingCounter
+	lastError        *statusError
+	stopped          bool
+	tokenRejected    bool
+	pollingDegraded  bool
+	outboundDegraded bool
+}
+
+func newInstallationStatus(installationID uuid.UUID, store Store, gateway Gateway, startAt time.Time, state store.InstallationState) *installationStatus {
+	lastUpdateAt := startAt
+	if !state.UpdatedAt.IsZero() {
+		lastUpdateAt = state.UpdatedAt.UTC()
+	}
+	return &installationStatus{
+		installationID: installationID,
+		store:          store,
+		gateway:        gateway,
+		startAt:        startAt.UTC(),
+		state:          statusHealthy,
+		lastUpdateAt:   lastUpdateAt,
+		lastUpdateID:   state.LastUpdateID,
+		lastOutboundAt: startAt.UTC(),
+	}
+}
+
+func (s *installationStatus) RecordPollSuccess(now time.Time, lastUpdateID int64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.lastUpdateAt = now.UTC()
+	if lastUpdateID > s.lastUpdateID {
+		s.lastUpdateID = lastUpdateID
+	}
+}
+
+func (s *installationStatus) RecordInbound(now time.Time) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.inboundMessages.add(now.UTC())
+}
+
+func (s *installationStatus) RecordOutbound(now time.Time) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.outboundMessages.add(now.UTC())
+	s.lastOutboundAt = now.UTC()
+}
+
+func (s *installationStatus) RecordError(now time.Time, message string) {
+	if strings.TrimSpace(message) == "" {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.lastError = &statusError{message: message, at: now.UTC()}
+}
+
+func (s *installationStatus) SetTokenRejected(rejected bool) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.tokenRejected == rejected {
+		return false
+	}
+	s.tokenRejected = rejected
+	return s.updateStateLocked()
+}
+
+func (s *installationStatus) TokenRejected() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.tokenRejected
+}
+
+func (s *installationStatus) SetPollingDegraded(degraded bool) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.pollingDegraded == degraded {
+		return false
+	}
+	s.pollingDegraded = degraded
+	return s.updateStateLocked()
+}
+
+func (s *installationStatus) SetOutboundDegraded(degraded bool) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.outboundDegraded == degraded {
+		return false
+	}
+	s.outboundDegraded = degraded
+	return s.updateStateLocked()
+}
+
+func (s *installationStatus) SetStopped(stopped bool) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.stopped == stopped {
+		return false
+	}
+	s.stopped = stopped
+	return s.updateStateLocked()
+}
+
+func (s *installationStatus) CurrentState() statusState {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.state
+}
+
+func (s *installationStatus) Report(ctx context.Context) {
+	s.reportMu.Lock()
+	defer s.reportMu.Unlock()
+
+	now := time.Now().UTC()
+	snapshot := s.snapshot(now)
+	activeChats, err := s.store.CountActiveChats(ctx, s.installationID)
+	if err != nil {
+		log.Printf("connector: count active chats error: %v", err)
+		s.RecordError(now, fmt.Sprintf("count active chats: %v", err))
+		activeChats = 0
+	}
+	blockedChats, err := s.store.CountBlockedChats(ctx, s.installationID)
+	if err != nil {
+		log.Printf("connector: count blocked chats error: %v", err)
+		s.RecordError(now, fmt.Sprintf("count blocked chats: %v", err))
+		blockedChats = 0
+	}
+	status := buildStatus(statusMetrics{
+		State:              snapshot.state,
+		StartAt:            snapshot.startAt,
+		LastUpdateAt:       snapshot.lastUpdateAt,
+		LastUpdateID:       snapshot.lastUpdateID,
+		ActiveChats:        activeChats,
+		BlockedChats:       blockedChats,
+		InboundMessages1h:  snapshot.inboundMessages1h,
+		OutboundMessages1h: snapshot.outboundMessages1h,
+		LastOutboundAt:     snapshot.lastOutboundAt,
+		LastError:          snapshot.lastError,
+	})
+	if err := s.gateway.ReportInstallationStatus(ctx, s.installationID.String(), status); err != nil {
+		log.Printf("connector: report status error: %v", err)
+		s.RecordError(now, fmt.Sprintf("report status: %v", err))
+	}
+}
+
+func (s *installationStatus) snapshot(now time.Time) statusSnapshot {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	lastError := s.lastError
+	if lastError != nil && now.Sub(lastError.at) > statusWindow {
+		lastError = nil
+	}
+	return statusSnapshot{
+		state:              s.state,
+		startAt:            s.startAt,
+		lastUpdateAt:       s.lastUpdateAt,
+		lastUpdateID:       s.lastUpdateID,
+		inboundMessages1h:  s.inboundMessages.count(now),
+		outboundMessages1h: s.outboundMessages.count(now),
+		lastOutboundAt:     s.lastOutboundAt,
+		lastError:          lastError,
+	}
+}
+
+func (s *installationStatus) updateStateLocked() bool {
+	state := statusHealthy
+	switch {
+	case s.stopped:
+		state = statusStopped
+	case s.tokenRejected:
+		state = statusMisconfigured
+	case s.pollingDegraded || s.outboundDegraded:
+		state = statusDegraded
+	}
+	if state == s.state {
+		return false
+	}
+	s.state = state
+	return true
+}
+
+func buildStatus(metrics statusMetrics) string {
+	headline := fmt.Sprintf("**%s** — polling since %s", metrics.State, formatTimestamp(metrics.StartAt))
+	lines := []string{
+		fmt.Sprintf("- last_update_at: %s", formatTimestamp(metrics.LastUpdateAt)),
+		fmt.Sprintf("- last_update_id: %d", metrics.LastUpdateID),
+		fmt.Sprintf("- active_chats: %d", metrics.ActiveChats),
+		fmt.Sprintf("- blocked_chats: %d", metrics.BlockedChats),
+		fmt.Sprintf("- inbound_messages_1h: %d", metrics.InboundMessages1h),
+		fmt.Sprintf("- outbound_messages_1h: %d", metrics.OutboundMessages1h),
+		fmt.Sprintf("- last_outbound_at: %s", formatTimestamp(metrics.LastOutboundAt)),
+	}
+	if metrics.LastError != nil {
+		lines = append(lines, fmt.Sprintf("- last_error: %s at %s", metrics.LastError.message, formatTimestamp(metrics.LastError.at)))
+	}
+	return headline + "\n\n" + strings.Join(lines, "\n")
+}
+
+func formatTimestamp(ts time.Time) string {
+	if ts.IsZero() {
+		ts = time.Unix(0, 0).UTC()
+	}
+	return ts.UTC().Format(time.RFC3339)
+}
+
+func formatStatusError(err error) string {
+	if err == nil {
+		return ""
+	}
+	var apiErr *telegram.APIError
+	if errors.As(err, &apiErr) {
+		detail := strings.TrimSpace(apiErr.Description)
+		if detail == "" {
+			detail = "telegram api error"
+		}
+		return fmt.Sprintf("telegram status=%d code=%d: %s", apiErr.StatusCode, apiErr.ErrorCode, detail)
+	}
+	var connectErr *connect.Error
+	if errors.As(err, &connectErr) {
+		detail := strings.TrimSpace(connectErr.Message())
+		if detail == "" {
+			detail = "gateway error"
+		}
+		return fmt.Sprintf("gateway %s: %s", connectErr.Code(), detail)
+	}
+	return err.Error()
+}

--- a/internal/connector/status_test.go
+++ b/internal/connector/status_test.go
@@ -21,9 +21,11 @@ func TestBuildStatusIncludesMetrics(t *testing.T) {
 		LastError:          &statusError{message: "telegram status=500", at: timestamp},
 	})
 
+	if !strings.HasPrefix(status, "Healthy\n\n") {
+		t.Fatalf("expected status to start with headline, got %q", status)
+	}
 	checks := []string{
-		"**Healthy**",
-		"polling since " + timestamp.Format(time.RFC3339),
+		"- status_since: " + timestamp.Format(time.RFC3339),
 		"- last_update_at: " + timestamp.Format(time.RFC3339),
 		"- last_update_id: 184522",
 		"- active_chats: 47",

--- a/internal/connector/status_test.go
+++ b/internal/connector/status_test.go
@@ -1,0 +1,41 @@
+package connector
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBuildStatusIncludesMetrics(t *testing.T) {
+	timestamp := time.Date(2026, 4, 23, 9, 4, 9, 0, time.UTC)
+	status := buildStatus(statusMetrics{
+		State:              statusHealthy,
+		StartAt:            timestamp,
+		LastUpdateAt:       timestamp,
+		LastUpdateID:       184522,
+		ActiveChats:        47,
+		BlockedChats:       2,
+		InboundMessages1h:  120,
+		OutboundMessages1h: 98,
+		LastOutboundAt:     timestamp,
+		LastError:          &statusError{message: "telegram status=500", at: timestamp},
+	})
+
+	checks := []string{
+		"**Healthy**",
+		"polling since " + timestamp.Format(time.RFC3339),
+		"- last_update_at: " + timestamp.Format(time.RFC3339),
+		"- last_update_id: 184522",
+		"- active_chats: 47",
+		"- blocked_chats: 2",
+		"- inbound_messages_1h: 120",
+		"- outbound_messages_1h: 98",
+		"- last_outbound_at: " + timestamp.Format(time.RFC3339),
+		"- last_error: telegram status=500 at " + timestamp.Format(time.RFC3339),
+	}
+	for _, check := range checks {
+		if !strings.Contains(status, check) {
+			t.Fatalf("expected status to contain %q, got %q", check, status)
+		}
+	}
+}

--- a/internal/connector/worker.go
+++ b/internal/connector/worker.go
@@ -2,22 +2,34 @@ package connector
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"sync"
 	"time"
 
+	appsv1 "github.com/agynio/telegram-connector/.gen/go/agynio/api/apps/v1"
 	"github.com/agynio/telegram-connector/internal/telegram"
 )
 
 type installationWorker struct {
-	installation   Installation
-	store          Store
-	gateway        Gateway
-	telegramClient *telegram.Client
-	pollTimeout    time.Duration
-	cancel         context.CancelFunc
-	done           chan struct{}
+	installation        Installation
+	store               Store
+	gateway             Gateway
+	telegramClient      *telegram.Client
+	pollTimeout         time.Duration
+	cancel              context.CancelFunc
+	done                chan struct{}
+	status              *installationStatus
+	telegramFailureAt   time.Time
+	telegramUnreachable bool
 }
+
+type stopReason int
+
+const (
+	stopReasonShutdown stopReason = iota
+	stopReasonRemoved
+)
 
 func newInstallationWorker(installation Installation, store Store, gatewayClient Gateway, telegramBaseURL string, pollTimeout time.Duration) *installationWorker {
 	return &installationWorker{
@@ -43,21 +55,41 @@ func (w *installationWorker) Start(parent context.Context) {
 	go w.run(ctx)
 }
 
-func (w *installationWorker) Stop() {
+func (w *installationWorker) Stop(reason stopReason) {
 	if w.cancel == nil {
 		return
 	}
+	w.reportStop(reason)
 	w.cancel()
 	<-w.done
 }
 
 func (w *installationWorker) run(ctx context.Context) {
 	defer close(w.done)
+	state, err := w.loadInstallationState(ctx)
+	if err != nil {
+		log.Printf("connector: load installation state %s error: %v", w.installation.ID, err)
+		return
+	}
+	startAt := time.Now().UTC()
+	w.status = newInstallationStatus(w.installation.ID, w.store, w.gateway, startAt, state)
+	w.appendAudit(ctx, auditEvent{
+		name:           auditEventPollingStarted,
+		message:        fmt.Sprintf("%s: polling started", auditEventPollingStarted),
+		level:          appsv1.InstallationAuditLogLevel_INSTALLATION_AUDIT_LOG_LEVEL_INFO,
+		idempotencyKey: auditKeyWithTime(auditEventPollingStarted, w.installation.ID, startAt),
+	})
+	w.status.Report(ctx)
+
+	statusCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	go w.runStatusReporter(statusCtx)
+
 	var wg sync.WaitGroup
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		if err := w.runInbound(ctx); err != nil {
+		if err := w.runInbound(ctx, state); err != nil {
 			log.Printf("connector: inbound worker %s stopped: %v", w.installation.ID, err)
 		}
 	}()
@@ -68,4 +100,43 @@ func (w *installationWorker) run(ctx context.Context) {
 		}
 	}()
 	wg.Wait()
+}
+
+func (w *installationWorker) reportStop(reason stopReason) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	w.appendAudit(ctx, auditEvent{
+		name:           auditEventPollingStopped,
+		message:        fmt.Sprintf("%s: polling stopped", auditEventPollingStopped),
+		level:          appsv1.InstallationAuditLogLevel_INSTALLATION_AUDIT_LOG_LEVEL_INFO,
+		idempotencyKey: auditKeyWithTime(auditEventPollingStopped, w.installation.ID, time.Now().UTC()),
+	})
+	if reason == stopReasonRemoved {
+		if err := w.gateway.ReportInstallationStatus(ctx, w.installation.ID.String(), ""); err != nil {
+			log.Printf("connector: clear status error: %v", err)
+			if w.status != nil {
+				w.status.RecordError(time.Now().UTC(), fmt.Sprintf("clear status: %v", err))
+			}
+		}
+		return
+	}
+	if w.status != nil {
+		w.status.SetStopped(true)
+		w.status.Report(ctx)
+	}
+}
+
+func (w *installationWorker) runStatusReporter(ctx context.Context) {
+	ticker := time.NewTicker(statusReportInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if w.status != nil {
+				w.status.Report(ctx)
+			}
+		}
+	}
 }

--- a/internal/connector/worker.go
+++ b/internal/connector/worker.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	appsv1 "github.com/agynio/telegram-connector/.gen/go/agynio/api/apps/v1"
+	"github.com/agynio/telegram-connector/internal/store"
 	"github.com/agynio/telegram-connector/internal/telegram"
 )
 
@@ -22,6 +23,8 @@ type installationWorker struct {
 	status              *installationStatus
 	telegramFailureAt   time.Time
 	telegramUnreachable bool
+	runInboundFn        func(context.Context, store.InstallationState) error
+	runOutboundFn       func(context.Context) error
 }
 
 type stopReason int
@@ -29,10 +32,11 @@ type stopReason int
 const (
 	stopReasonShutdown stopReason = iota
 	stopReasonRemoved
+	stopReasonMisconfigured
 )
 
 func newInstallationWorker(installation Installation, store Store, gatewayClient Gateway, telegramBaseURL string, pollTimeout time.Duration) *installationWorker {
-	return &installationWorker{
+	worker := &installationWorker{
 		installation:   installation,
 		store:          store,
 		gateway:        gatewayClient,
@@ -40,6 +44,9 @@ func newInstallationWorker(installation Installation, store Store, gatewayClient
 		pollTimeout:    pollTimeout,
 		done:           make(chan struct{}),
 	}
+	worker.runInboundFn = worker.runInbound
+	worker.runOutboundFn = worker.runOutbound
+	return worker
 }
 
 func (w *installationWorker) Installation() Installation {
@@ -89,13 +96,13 @@ func (w *installationWorker) run(ctx context.Context) {
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		if err := w.runInbound(ctx, state); err != nil {
+		if err := w.runInboundFn(ctx, state); err != nil {
 			log.Printf("connector: inbound worker %s stopped: %v", w.installation.ID, err)
 		}
 	}()
 	go func() {
 		defer wg.Done()
-		if err := w.runOutbound(ctx); err != nil {
+		if err := w.runOutboundFn(ctx); err != nil {
 			log.Printf("connector: outbound worker %s stopped: %v", w.installation.ID, err)
 		}
 	}()
@@ -118,6 +125,9 @@ func (w *installationWorker) reportStop(reason stopReason) {
 				w.status.RecordError(time.Now().UTC(), fmt.Sprintf("clear status: %v", err))
 			}
 		}
+		return
+	}
+	if reason == stopReasonMisconfigured {
 		return
 	}
 	if w.status != nil {

--- a/internal/connector/worker_audit_test.go
+++ b/internal/connector/worker_audit_test.go
@@ -1,0 +1,334 @@
+package connector
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	appsv1 "github.com/agynio/telegram-connector/.gen/go/agynio/api/apps/v1"
+	"github.com/agynio/telegram-connector/internal/store"
+)
+
+func TestWorkerRunEmitsPollingStartedAudit(t *testing.T) {
+	installationID := uuid.New()
+	organizationID := uuid.New()
+	agentID := uuid.New()
+	statusCalls := 0
+	auditCalls := 0
+
+	storeStub := &stubStore{
+		t: t,
+		getInstallationStateFn: func(context.Context, uuid.UUID) (store.InstallationState, error) {
+			return store.InstallationState{}, nil
+		},
+		countActiveChatsFn: func(context.Context, uuid.UUID) (int64, error) {
+			return 0, nil
+		},
+		countBlockedChatsFn: func(context.Context, uuid.UUID) (int64, error) {
+			return 0, nil
+		},
+	}
+
+	gatewayStub := &stubGateway{
+		t: t,
+		reportStatusFn: func(_ context.Context, installationArg, status string) error {
+			statusCalls++
+			if installationArg != installationID.String() {
+				t.Fatalf("expected installation %s, got %s", installationID, installationArg)
+			}
+			if !strings.HasPrefix(status, "Healthy\n\n") {
+				t.Fatalf("expected healthy headline, got %q", status)
+			}
+			return nil
+		},
+		appendAuditFn: func(_ context.Context, installationArg, message string, level appsv1.InstallationAuditLogLevel, idempotencyKey string) error {
+			auditCalls++
+			if installationArg != installationID.String() {
+				t.Fatalf("expected installation %s, got %s", installationID, installationArg)
+			}
+			if level != appsv1.InstallationAuditLogLevel_INSTALLATION_AUDIT_LOG_LEVEL_INFO {
+				t.Fatalf("expected info level, got %v", level)
+			}
+			if !strings.Contains(message, auditEventPollingStarted) {
+				t.Fatalf("expected polling_started message, got %q", message)
+			}
+			prefix := auditEventPollingStarted + ":" + installationID.String() + ":"
+			if !strings.HasPrefix(idempotencyKey, prefix) {
+				t.Fatalf("expected idempotency key prefix %q, got %q", prefix, idempotencyKey)
+			}
+			return nil
+		},
+	}
+
+	worker := newInstallationWorker(Installation{
+		ID:             installationID,
+		OrganizationID: organizationID,
+		BotToken:       "token",
+		AgentID:        agentID,
+	}, storeStub, gatewayStub, "http://telegram.test", time.Second)
+	worker.runInboundFn = func(context.Context, store.InstallationState) error {
+		return nil
+	}
+	worker.runOutboundFn = func(context.Context) error {
+		return nil
+	}
+
+	worker.run(context.Background())
+
+	if statusCalls != 1 {
+		t.Fatalf("expected 1 status report, got %d", statusCalls)
+	}
+	if auditCalls != 1 {
+		t.Fatalf("expected 1 audit entry, got %d", auditCalls)
+	}
+}
+
+func TestReportStopClearsStatusOnRemoval(t *testing.T) {
+	installationID := uuid.New()
+	organizationID := uuid.New()
+	agentID := uuid.New()
+	statusCalls := 0
+	auditCalls := 0
+
+	gatewayStub := &stubGateway{
+		t: t,
+		reportStatusFn: func(_ context.Context, installationArg, status string) error {
+			statusCalls++
+			if installationArg != installationID.String() {
+				t.Fatalf("expected installation %s, got %s", installationID, installationArg)
+			}
+			if status != "" {
+				t.Fatalf("expected cleared status, got %q", status)
+			}
+			return nil
+		},
+		appendAuditFn: func(_ context.Context, installationArg, message string, level appsv1.InstallationAuditLogLevel, idempotencyKey string) error {
+			auditCalls++
+			if installationArg != installationID.String() {
+				t.Fatalf("expected installation %s, got %s", installationID, installationArg)
+			}
+			if !strings.Contains(message, auditEventPollingStopped) {
+				t.Fatalf("expected polling_stopped message, got %q", message)
+			}
+			if strings.TrimSpace(idempotencyKey) == "" {
+				t.Fatal("expected idempotency key")
+			}
+			return nil
+		},
+	}
+
+	worker := newInstallationWorker(Installation{
+		ID:             installationID,
+		OrganizationID: organizationID,
+		BotToken:       "token",
+		AgentID:        agentID,
+	}, &stubStore{t: t}, gatewayStub, "http://telegram.test", time.Second)
+
+	worker.reportStop(stopReasonRemoved)
+
+	if statusCalls != 1 {
+		t.Fatalf("expected 1 status clear, got %d", statusCalls)
+	}
+	if auditCalls != 1 {
+		t.Fatalf("expected 1 audit entry, got %d", auditCalls)
+	}
+}
+
+func TestReportStopMisconfiguredDoesNotClearStatus(t *testing.T) {
+	installationID := uuid.New()
+	organizationID := uuid.New()
+	agentID := uuid.New()
+	statusCalls := 0
+	auditCalls := 0
+
+	gatewayStub := &stubGateway{
+		t: t,
+		reportStatusFn: func(context.Context, string, string) error {
+			statusCalls++
+			return nil
+		},
+		appendAuditFn: func(_ context.Context, installationArg, message string, level appsv1.InstallationAuditLogLevel, idempotencyKey string) error {
+			auditCalls++
+			if installationArg != installationID.String() {
+				t.Fatalf("expected installation %s, got %s", installationID, installationArg)
+			}
+			if !strings.Contains(message, auditEventPollingStopped) {
+				t.Fatalf("expected polling_stopped message, got %q", message)
+			}
+			if strings.TrimSpace(idempotencyKey) == "" {
+				t.Fatal("expected idempotency key")
+			}
+			return nil
+		},
+	}
+
+	worker := newInstallationWorker(Installation{
+		ID:             installationID,
+		OrganizationID: organizationID,
+		BotToken:       "token",
+		AgentID:        agentID,
+	}, &stubStore{t: t}, gatewayStub, "http://telegram.test", time.Second)
+
+	worker.reportStop(stopReasonMisconfigured)
+
+	if statusCalls != 0 {
+		t.Fatalf("expected no status clear, got %d", statusCalls)
+	}
+	if auditCalls != 1 {
+		t.Fatalf("expected 1 audit entry, got %d", auditCalls)
+	}
+}
+
+func TestHandleTokenRejectedEmitsAuditOnce(t *testing.T) {
+	installationID := uuid.New()
+	organizationID := uuid.New()
+	agentID := uuid.New()
+	now := time.Date(2026, 4, 23, 10, 5, 0, 0, time.UTC)
+	statusCalls := 0
+	auditCalls := 0
+
+	storeStub := &stubStore{
+		t: t,
+		countActiveChatsFn: func(context.Context, uuid.UUID) (int64, error) {
+			return 0, nil
+		},
+		countBlockedChatsFn: func(context.Context, uuid.UUID) (int64, error) {
+			return 0, nil
+		},
+	}
+
+	gatewayStub := &stubGateway{
+		t: t,
+		reportStatusFn: func(_ context.Context, installationArg, status string) error {
+			statusCalls++
+			if installationArg != installationID.String() {
+				t.Fatalf("expected installation %s, got %s", installationID, installationArg)
+			}
+			if !strings.HasPrefix(status, "Misconfigured\n\n") {
+				t.Fatalf("expected misconfigured headline, got %q", status)
+			}
+			return nil
+		},
+		appendAuditFn: func(_ context.Context, installationArg, message string, level appsv1.InstallationAuditLogLevel, idempotencyKey string) error {
+			auditCalls++
+			if installationArg != installationID.String() {
+				t.Fatalf("expected installation %s, got %s", installationID, installationArg)
+			}
+			if !strings.Contains(message, auditEventBotTokenRejected) {
+				t.Fatalf("expected bot_token_rejected message, got %q", message)
+			}
+			expected := auditKeyWithTime(auditEventBotTokenRejected, installationID, now)
+			if idempotencyKey != expected {
+				t.Fatalf("expected idempotency key %q, got %q", expected, idempotencyKey)
+			}
+			return nil
+		},
+	}
+
+	worker := newInstallationWorker(Installation{
+		ID:             installationID,
+		OrganizationID: organizationID,
+		BotToken:       "token",
+		AgentID:        agentID,
+	}, storeStub, gatewayStub, "http://telegram.test", time.Second)
+	worker.status = newInstallationStatus(installationID, storeStub, gatewayStub, now, store.InstallationState{})
+
+	worker.handleTokenRejected(context.Background(), now)
+	worker.handleTokenRejected(context.Background(), now.Add(time.Minute))
+
+	if statusCalls != 1 {
+		t.Fatalf("expected 1 status report, got %d", statusCalls)
+	}
+	if auditCalls != 1 {
+		t.Fatalf("expected 1 audit entry, got %d", auditCalls)
+	}
+	if worker.status.CurrentState() != statusMisconfigured {
+		t.Fatalf("expected misconfigured state, got %s", worker.status.CurrentState())
+	}
+}
+
+func TestHandlePollErrorUnreachableAndRecovered(t *testing.T) {
+	installationID := uuid.New()
+	organizationID := uuid.New()
+	agentID := uuid.New()
+	start := time.Date(2026, 4, 23, 11, 0, 0, 0, time.UTC)
+	auditEvents := make([]string, 0, 2)
+	second := time.Time{}
+
+	storeStub := &stubStore{
+		t: t,
+		countActiveChatsFn: func(context.Context, uuid.UUID) (int64, error) {
+			return 0, nil
+		},
+		countBlockedChatsFn: func(context.Context, uuid.UUID) (int64, error) {
+			return 0, nil
+		},
+	}
+
+	gatewayStub := &stubGateway{
+		t: t,
+		reportStatusFn: func(context.Context, string, string) error {
+			return nil
+		},
+		appendAuditFn: func(_ context.Context, installationArg, message string, level appsv1.InstallationAuditLogLevel, idempotencyKey string) error {
+			if installationArg != installationID.String() {
+				t.Fatalf("expected installation %s, got %s", installationID, installationArg)
+			}
+			if strings.TrimSpace(idempotencyKey) == "" {
+				t.Fatal("expected idempotency key")
+			}
+			event := strings.SplitN(message, ":", 2)[0]
+			auditEvents = append(auditEvents, event)
+			if event == auditEventTelegramUnreachable {
+				expected := auditKeyWithTime(auditEventTelegramUnreachable, installationID, start)
+				if idempotencyKey != expected {
+					t.Fatalf("expected idempotency key %q, got %q", expected, idempotencyKey)
+				}
+			}
+			if event == auditEventTelegramRecovered {
+				expected := auditKeyWithTime(auditEventTelegramRecovered, installationID, second.Add(time.Second))
+				if idempotencyKey != expected {
+					t.Fatalf("expected idempotency key %q, got %q", expected, idempotencyKey)
+				}
+			}
+			return nil
+		},
+	}
+
+	worker := newInstallationWorker(Installation{
+		ID:             installationID,
+		OrganizationID: organizationID,
+		BotToken:       "token",
+		AgentID:        agentID,
+	}, storeStub, gatewayStub, "http://telegram.test", time.Second)
+	worker.status = newInstallationStatus(installationID, storeStub, gatewayStub, start, store.InstallationState{})
+
+	worker.handlePollError(context.Background(), start, errTest("getUpdates failed"))
+	if len(auditEvents) != 0 {
+		t.Fatalf("expected no audits yet, got %v", auditEvents)
+	}
+	second = start.Add(telegramUnreachableTimeout + time.Second)
+	worker.handlePollError(context.Background(), second, errTest("getUpdates failed"))
+
+	if len(auditEvents) != 1 || auditEvents[0] != auditEventTelegramUnreachable {
+		t.Fatalf("expected unreachable audit, got %v", auditEvents)
+	}
+
+	worker.handlePollSuccess(context.Background(), second.Add(time.Second))
+
+	if len(auditEvents) != 2 || auditEvents[1] != auditEventTelegramRecovered {
+		t.Fatalf("expected recovered audit, got %v", auditEvents)
+	}
+	if worker.telegramUnreachable {
+		t.Fatal("expected telegramUnreachable reset")
+	}
+}
+
+type errTest string
+
+func (e errTest) Error() string {
+	return string(e)
+}

--- a/internal/gateway/client.go
+++ b/internal/gateway/client.go
@@ -92,13 +92,15 @@ func (c *Client) ReportInstallationStatus(ctx context.Context, installationID, s
 }
 
 func (c *Client) AppendInstallationAuditLogEntry(ctx context.Context, installationID, message string, level appsv1.InstallationAuditLogLevel, idempotencyKey string) error {
+	key := strings.TrimSpace(idempotencyKey)
+	if key == "" {
+		return fmt.Errorf("append installation audit log entry: idempotency key required")
+	}
 	request := &appsv1.AppendInstallationAuditLogEntryRequest{
 		InstallationId: installationID,
 		Message:        message,
 		Level:          level,
-	}
-	if strings.TrimSpace(idempotencyKey) != "" {
-		request.IdempotencyKey = &idempotencyKey
+		IdempotencyKey: &key,
 	}
 	_, err := c.apps.AppendInstallationAuditLogEntry(ctx, connect.NewRequest(request))
 	if err != nil {

--- a/internal/gateway/client.go
+++ b/internal/gateway/client.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"strings"
 
 	"connectrpc.com/connect"
 	"github.com/openziti/sdk-golang/ziti"
@@ -77,6 +78,33 @@ func (c *Client) ListInstallations(ctx context.Context, appID string) ([]*appsv1
 			return installations, nil
 		}
 	}
+}
+
+func (c *Client) ReportInstallationStatus(ctx context.Context, installationID, status string) error {
+	_, err := c.apps.ReportInstallationStatus(ctx, connect.NewRequest(&appsv1.ReportInstallationStatusRequest{
+		InstallationId: installationID,
+		Status:         status,
+	}))
+	if err != nil {
+		return fmt.Errorf("report installation status: %w", err)
+	}
+	return nil
+}
+
+func (c *Client) AppendInstallationAuditLogEntry(ctx context.Context, installationID, message string, level appsv1.InstallationAuditLogLevel, idempotencyKey string) error {
+	request := &appsv1.AppendInstallationAuditLogEntryRequest{
+		InstallationId: installationID,
+		Message:        message,
+		Level:          level,
+	}
+	if strings.TrimSpace(idempotencyKey) != "" {
+		request.IdempotencyKey = &idempotencyKey
+	}
+	_, err := c.apps.AppendInstallationAuditLogEntry(ctx, connect.NewRequest(request))
+	if err != nil {
+		return fmt.Errorf("append installation audit log entry: %w", err)
+	}
+	return nil
 }
 
 func (c *Client) CreateThread(ctx context.Context, organizationID string) (*threadsv1.Thread, error) {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -32,6 +32,11 @@ type ChatMappingInput struct {
 	ThreadID       uuid.UUID
 }
 
+type InstallationState struct {
+	LastUpdateID int64
+	UpdatedAt    time.Time
+}
+
 func NewStore(pool *pgxpool.Pool) *Store {
 	return &Store{pool: pool}
 }
@@ -96,42 +101,68 @@ func (s *Store) DeleteChatMapping(ctx context.Context, installationID uuid.UUID,
 	return nil
 }
 
-func (s *Store) ClearChatBlocked(ctx context.Context, installationID uuid.UUID, chatID int64) error {
-	if _, err := s.pool.Exec(ctx, `
+func (s *Store) ClearChatBlocked(ctx context.Context, installationID uuid.UUID, chatID int64) (bool, error) {
+	result, err := s.pool.Exec(ctx, `
         UPDATE chat_mappings
         SET blocked_at = NULL
         WHERE installation_id = $1 AND telegram_chat_id = $2 AND blocked_at IS NOT NULL
-    `, installationID, chatID); err != nil {
-		return fmt.Errorf("clear chat blocked: %w", err)
+    `, installationID, chatID)
+	if err != nil {
+		return false, fmt.Errorf("clear chat blocked: %w", err)
 	}
-	return nil
+	return result.RowsAffected() > 0, nil
 }
 
-func (s *Store) MarkChatBlocked(ctx context.Context, installationID uuid.UUID, chatID int64) error {
-	if _, err := s.pool.Exec(ctx, `
+func (s *Store) MarkChatBlocked(ctx context.Context, installationID uuid.UUID, chatID int64) (bool, error) {
+	result, err := s.pool.Exec(ctx, `
         UPDATE chat_mappings
         SET blocked_at = NOW()
-        WHERE installation_id = $1 AND telegram_chat_id = $2
-    `, installationID, chatID); err != nil {
-		return fmt.Errorf("mark chat blocked: %w", err)
+        WHERE installation_id = $1 AND telegram_chat_id = $2 AND blocked_at IS NULL
+    `, installationID, chatID)
+	if err != nil {
+		return false, fmt.Errorf("mark chat blocked: %w", err)
 	}
-	return nil
+	return result.RowsAffected() > 0, nil
 }
 
-func (s *Store) GetInstallationState(ctx context.Context, installationID uuid.UUID) (int64, error) {
-	var lastUpdate int64
+func (s *Store) CountActiveChats(ctx context.Context, installationID uuid.UUID) (int64, error) {
+	var count int64
+	if err := s.pool.QueryRow(ctx, `
+        SELECT COUNT(*)
+        FROM chat_mappings
+        WHERE installation_id = $1 AND blocked_at IS NULL
+    `, installationID).Scan(&count); err != nil {
+		return 0, fmt.Errorf("count active chats: %w", err)
+	}
+	return count, nil
+}
+
+func (s *Store) CountBlockedChats(ctx context.Context, installationID uuid.UUID) (int64, error) {
+	var count int64
+	if err := s.pool.QueryRow(ctx, `
+        SELECT COUNT(*)
+        FROM chat_mappings
+        WHERE installation_id = $1 AND blocked_at IS NOT NULL
+    `, installationID).Scan(&count); err != nil {
+		return 0, fmt.Errorf("count blocked chats: %w", err)
+	}
+	return count, nil
+}
+
+func (s *Store) GetInstallationState(ctx context.Context, installationID uuid.UUID) (InstallationState, error) {
+	var state InstallationState
 	err := s.pool.QueryRow(ctx, `
-        SELECT last_update_id
+        SELECT last_update_id, updated_at
         FROM installation_state
         WHERE installation_id = $1
-    `, installationID).Scan(&lastUpdate)
+    `, installationID).Scan(&state.LastUpdateID, &state.UpdatedAt)
 	if err == nil {
-		return lastUpdate, nil
+		return state, nil
 	}
 	if errors.Is(err, pgx.ErrNoRows) {
-		return 0, nil
+		return InstallationState{}, nil
 	}
-	return 0, fmt.Errorf("get installation state: %w", err)
+	return InstallationState{}, fmt.Errorf("get installation state: %w", err)
 }
 
 func (s *Store) UpsertInstallationState(ctx context.Context, installationID uuid.UUID, lastUpdateID int64) error {

--- a/test/e2e/harness_env_test.go
+++ b/test/e2e/harness_env_test.go
@@ -1,0 +1,174 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"time"
+
+	"google.golang.org/grpc"
+
+	appsv1 "github.com/agynio/telegram-connector/.gen/go/agynio/api/apps/v1"
+	filesv1 "github.com/agynio/telegram-connector/.gen/go/agynio/api/files/v1"
+	"github.com/agynio/telegram-connector/.gen/go/agynio/api/gateway/v1/gatewayv1connect"
+	notificationsv1 "github.com/agynio/telegram-connector/.gen/go/agynio/api/notifications/v1"
+	organizationsv1 "github.com/agynio/telegram-connector/.gen/go/agynio/api/organizations/v1"
+	threadsv1 "github.com/agynio/telegram-connector/.gen/go/agynio/api/threads/v1"
+	"github.com/agynio/telegram-connector/internal/connector"
+	"github.com/agynio/telegram-connector/internal/gateway"
+)
+
+type localEnvironment struct {
+	state             *testState
+	store             *memoryStore
+	appsAddr          string
+	organizationsAddr string
+	threadsAddr       string
+	filesAddr         string
+	notificationsAddr string
+	gatewayAddr       string
+	connectorAddr     string
+	telegramAddr      string
+	grpcServers       []*grpc.Server
+	httpServers       []*http.Server
+	connectorCancel   context.CancelFunc
+}
+
+func startLocalEnvironment() (*localEnvironment, error) {
+	state := newTestState()
+	env := &localEnvironment{
+		state: state,
+		store: newMemoryStore(),
+	}
+
+	appsAddr, appsServer, err := startGRPCServer(func(server *grpc.Server) {
+		appsv1.RegisterAppsServiceServer(server, &appsService{state: state})
+	})
+	if err != nil {
+		return nil, err
+	}
+	orgAddr, orgServer, err := startGRPCServer(func(server *grpc.Server) {
+		organizationsv1.RegisterOrganizationsServiceServer(server, &organizationsService{state: state})
+	})
+	if err != nil {
+		return nil, err
+	}
+	threadsAddr, threadsServer, err := startGRPCServer(func(server *grpc.Server) {
+		threadsv1.RegisterThreadsServiceServer(server, &threadsService{state: state})
+	})
+	if err != nil {
+		return nil, err
+	}
+	filesAddr, filesServer, err := startGRPCServer(func(server *grpc.Server) {
+		filesv1.RegisterFilesServiceServer(server, &filesService{state: state})
+	})
+	if err != nil {
+		return nil, err
+	}
+	notificationsAddr, notificationsServer, err := startGRPCServer(func(server *grpc.Server) {
+		notificationsv1.RegisterNotificationsServiceServer(server, &notificationsService{state: state})
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	gatewayAddr, gatewayServer, err := startGatewayServer(state)
+	if err != nil {
+		return nil, err
+	}
+
+	telegramAddr, telegramServer, err := startTelegramMockServer()
+	if err != nil {
+		return nil, err
+	}
+
+	connectorAddr, connectorServer, err := startHealthServer()
+	if err != nil {
+		return nil, err
+	}
+
+	env.appsAddr = appsAddr
+	env.organizationsAddr = orgAddr
+	env.threadsAddr = threadsAddr
+	env.filesAddr = filesAddr
+	env.notificationsAddr = notificationsAddr
+	env.gatewayAddr = gatewayAddr
+	env.telegramAddr = telegramAddr
+	env.connectorAddr = connectorAddr
+	env.grpcServers = []*grpc.Server{appsServer, orgServer, threadsServer, filesServer, notificationsServer}
+	env.httpServers = []*http.Server{gatewayServer, telegramServer, connectorServer}
+	return env, nil
+}
+
+func (e *localEnvironment) StartConnector(appID, appIdentityID string) {
+	client := gateway.NewClient(http.DefaultClient, "http://"+e.gatewayAddr, appIdentityID)
+	service := connector.NewService(e.store, client, connector.ServiceConfig{
+		AppID:           appID,
+		TelegramBaseURL: "http://" + e.telegramAddr,
+		PollTimeout:     2 * time.Second,
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	e.connectorCancel = cancel
+	go service.Run(ctx)
+}
+
+func (e *localEnvironment) Shutdown() {
+	if e.connectorCancel != nil {
+		e.connectorCancel()
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	for _, srv := range e.httpServers {
+		_ = srv.Shutdown(ctx)
+	}
+	for _, srv := range e.grpcServers {
+		srv.Stop()
+	}
+}
+
+func startGRPCServer(register func(*grpc.Server)) (string, *grpc.Server, error) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return "", nil, err
+	}
+	server := grpc.NewServer()
+	register(server)
+	go server.Serve(listener)
+	return listener.Addr().String(), server, nil
+}
+
+func startGatewayServer(state *testState) (string, *http.Server, error) {
+	mux := http.NewServeMux()
+	appsPath, appsHandler := gatewayv1connect.NewAppsGatewayHandler(&appsGatewayServer{state: state})
+	mux.Handle(appsPath, appsHandler)
+	threadsPath, threadsHandler := gatewayv1connect.NewThreadsGatewayHandler(&threadsGatewayServer{state: state})
+	mux.Handle(threadsPath, threadsHandler)
+	filesPath, filesHandler := gatewayv1connect.NewFilesGatewayHandler(&filesGatewayServer{state: state})
+	mux.Handle(filesPath, filesHandler)
+	notifyPath, notifyHandler := gatewayv1connect.NewNotificationsGatewayHandler(&notificationsGatewayServer{state: state})
+	mux.Handle(notifyPath, notifyHandler)
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return "", nil, err
+	}
+	server := &http.Server{Handler: mux}
+	go server.Serve(listener)
+	return listener.Addr().String(), server, nil
+}
+
+func startHealthServer() (string, *http.Server, error) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return "", nil, err
+	}
+	server := &http.Server{Handler: mux}
+	go server.Serve(listener)
+	return listener.Addr().String(), server, nil
+}

--- a/test/e2e/harness_services_test.go
+++ b/test/e2e/harness_services_test.go
@@ -1,0 +1,331 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"errors"
+	"io"
+
+	"connectrpc.com/connect"
+	"github.com/google/uuid"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	appsv1 "github.com/agynio/telegram-connector/.gen/go/agynio/api/apps/v1"
+	filesv1 "github.com/agynio/telegram-connector/.gen/go/agynio/api/files/v1"
+	"github.com/agynio/telegram-connector/.gen/go/agynio/api/gateway/v1/gatewayv1connect"
+	notificationsv1 "github.com/agynio/telegram-connector/.gen/go/agynio/api/notifications/v1"
+	organizationsv1 "github.com/agynio/telegram-connector/.gen/go/agynio/api/organizations/v1"
+	threadsv1 "github.com/agynio/telegram-connector/.gen/go/agynio/api/threads/v1"
+)
+
+type appsService struct {
+	appsv1.UnimplementedAppsServiceServer
+	state *testState
+}
+
+func (s *appsService) CreateApp(_ context.Context, req *appsv1.CreateAppRequest) (*appsv1.CreateAppResponse, error) {
+	app, token, err := s.state.createApp(req)
+	if err != nil {
+		return nil, err
+	}
+	return &appsv1.CreateAppResponse{App: app, ServiceToken: token}, nil
+}
+
+func (s *appsService) InstallApp(_ context.Context, req *appsv1.InstallAppRequest) (*appsv1.InstallAppResponse, error) {
+	installation, err := s.state.installApp(req.GetAppId(), req.GetOrganizationId(), req.GetConfiguration())
+	if err != nil {
+		return nil, err
+	}
+	return &appsv1.InstallAppResponse{Installation: installation}, nil
+}
+
+func (s *appsService) UpdateInstallation(_ context.Context, req *appsv1.UpdateInstallationRequest) (*appsv1.UpdateInstallationResponse, error) {
+	installation, err := s.state.updateInstallation(req.GetId(), req.GetConfiguration())
+	if err != nil {
+		return nil, err
+	}
+	return &appsv1.UpdateInstallationResponse{Installation: installation}, nil
+}
+
+func (s *appsService) UninstallApp(_ context.Context, req *appsv1.UninstallAppRequest) (*appsv1.UninstallAppResponse, error) {
+	if err := s.state.uninstallApp(req.GetId()); err != nil {
+		return nil, err
+	}
+	return &appsv1.UninstallAppResponse{}, nil
+}
+
+func (s *appsService) DeleteApp(_ context.Context, req *appsv1.DeleteAppRequest) (*appsv1.DeleteAppResponse, error) {
+	s.state.deleteApp(req.GetId())
+	return &appsv1.DeleteAppResponse{}, nil
+}
+
+type organizationsService struct {
+	organizationsv1.UnimplementedOrganizationsServiceServer
+	state *testState
+}
+
+func (s *organizationsService) CreateOrganization(_ context.Context, req *organizationsv1.CreateOrganizationRequest) (*organizationsv1.CreateOrganizationResponse, error) {
+	organization := s.state.createOrganization(req.GetName())
+	return &organizationsv1.CreateOrganizationResponse{Organization: organization}, nil
+}
+
+func (s *organizationsService) DeleteOrganization(_ context.Context, req *organizationsv1.DeleteOrganizationRequest) (*organizationsv1.DeleteOrganizationResponse, error) {
+	s.state.deleteOrganization(req.GetId())
+	return &organizationsv1.DeleteOrganizationResponse{}, nil
+}
+
+type threadsService struct {
+	threadsv1.UnimplementedThreadsServiceServer
+	state *testState
+}
+
+func (s *threadsService) CreateThread(_ context.Context, req *threadsv1.CreateThreadRequest) (*threadsv1.CreateThreadResponse, error) {
+	thread := s.state.createThread(req.GetOrganizationId())
+	return &threadsv1.CreateThreadResponse{Thread: thread}, nil
+}
+
+func (s *threadsService) AddParticipant(_ context.Context, req *threadsv1.AddParticipantRequest) (*threadsv1.AddParticipantResponse, error) {
+	participantID := ""
+	if req.GetParticipant() != nil {
+		participantID = req.GetParticipant().GetParticipantId()
+	}
+	if participantID == "" {
+		return nil, status.Error(codes.InvalidArgument, "participant_id required")
+	}
+	thread, err := s.state.addParticipant(req.GetThreadId(), participantID, req.GetPassive())
+	if err != nil {
+		return nil, err
+	}
+	return &threadsv1.AddParticipantResponse{Thread: thread}, nil
+}
+
+func (s *threadsService) SendMessage(_ context.Context, req *threadsv1.SendMessageRequest) (*threadsv1.SendMessageResponse, error) {
+	message, err := s.state.sendMessage(req.GetThreadId(), req.GetSenderId(), req.GetBody(), req.GetFileIds())
+	if err != nil {
+		return nil, err
+	}
+	return &threadsv1.SendMessageResponse{Message: message}, nil
+}
+
+func (s *threadsService) GetThreads(_ context.Context, req *threadsv1.GetThreadsRequest) (*threadsv1.GetThreadsResponse, error) {
+	threads := s.state.listThreads(req.GetParticipantId())
+	return &threadsv1.GetThreadsResponse{Threads: threads}, nil
+}
+
+func (s *threadsService) GetMessages(_ context.Context, req *threadsv1.GetMessagesRequest) (*threadsv1.GetMessagesResponse, error) {
+	messages, err := s.state.listMessages(req.GetThreadId())
+	if err != nil {
+		return nil, err
+	}
+	return &threadsv1.GetMessagesResponse{Messages: messages}, nil
+}
+
+func (s *threadsService) GetUnackedMessages(_ context.Context, req *threadsv1.GetUnackedMessagesRequest) (*threadsv1.GetUnackedMessagesResponse, error) {
+	messages := s.state.listUnackedMessages(req.GetParticipantId())
+	return &threadsv1.GetUnackedMessagesResponse{Messages: messages}, nil
+}
+
+func (s *threadsService) AckMessages(_ context.Context, req *threadsv1.AckMessagesRequest) (*threadsv1.AckMessagesResponse, error) {
+	s.state.ackMessages(req.GetParticipantId(), req.GetMessageIds())
+	return &threadsv1.AckMessagesResponse{}, nil
+}
+
+type filesService struct {
+	filesv1.UnimplementedFilesServiceServer
+	state *testState
+}
+
+func (s *filesService) UploadFile(stream filesv1.FilesService_UploadFileServer) error {
+	var metadata *filesv1.UploadFileMetadata
+	data := make([]byte, 0)
+	for {
+		req, err := stream.Recv()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		if meta := req.GetMetadata(); meta != nil {
+			metadata = meta
+			continue
+		}
+		if chunk := req.GetChunk(); chunk != nil {
+			data = append(data, chunk.GetData()...)
+		}
+	}
+	if metadata == nil {
+		return status.Error(codes.InvalidArgument, "metadata required")
+	}
+	file := s.state.addFile(metadata, data)
+	return stream.SendAndClose(&filesv1.UploadFileResponse{File: file})
+}
+
+func (s *filesService) GetFileMetadata(_ context.Context, req *filesv1.GetFileMetadataRequest) (*filesv1.GetFileMetadataResponse, error) {
+	info, _, err := s.state.getFile(req.GetFileId())
+	if err != nil {
+		return nil, err
+	}
+	return &filesv1.GetFileMetadataResponse{File: info}, nil
+}
+
+func (s *filesService) GetFileContent(req *filesv1.GetFileContentRequest, stream filesv1.FilesService_GetFileContentServer) error {
+	_, data, err := s.state.getFile(req.GetFileId())
+	if err != nil {
+		return err
+	}
+	return stream.Send(&filesv1.GetFileContentResponse{ChunkData: data})
+}
+
+type notificationsService struct {
+	notificationsv1.UnimplementedNotificationsServiceServer
+	state *testState
+}
+
+func (s *notificationsService) Publish(_ context.Context, req *notificationsv1.PublishRequest) (*notificationsv1.PublishResponse, error) {
+	envelope := &notificationsv1.NotificationEnvelope{
+		Id:      uuid.NewString(),
+		Ts:      timestamppb.Now(),
+		Source:  req.GetSource(),
+		Event:   req.GetEvent(),
+		Rooms:   req.GetRooms(),
+		Payload: req.GetPayload(),
+	}
+	s.state.publishNotification(envelope)
+	return &notificationsv1.PublishResponse{Id: envelope.Id, Ts: envelope.Ts}, nil
+}
+
+type appsGatewayServer struct {
+	gatewayv1connect.UnimplementedAppsGatewayHandler
+	state *testState
+}
+
+func (s *appsGatewayServer) ListInstallations(_ context.Context, req *connect.Request[appsv1.ListInstallationsRequest]) (*connect.Response[appsv1.ListInstallationsResponse], error) {
+	installations := s.state.listInstallations(req.Msg.GetAppId())
+	return connect.NewResponse(&appsv1.ListInstallationsResponse{Installations: installations}), nil
+}
+
+func (s *appsGatewayServer) ReportInstallationStatus(_ context.Context, req *connect.Request[appsv1.ReportInstallationStatusRequest]) (*connect.Response[appsv1.ReportInstallationStatusResponse], error) {
+	if err := s.state.reportInstallationStatus(req.Msg.GetInstallationId(), req.Msg.GetStatus()); err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(&appsv1.ReportInstallationStatusResponse{}), nil
+}
+
+func (s *appsGatewayServer) AppendInstallationAuditLogEntry(_ context.Context, req *connect.Request[appsv1.AppendInstallationAuditLogEntryRequest]) (*connect.Response[appsv1.AppendInstallationAuditLogEntryResponse], error) {
+	entry := s.state.appendAudit(req.Msg.GetInstallationId(), req.Msg.GetMessage(), req.Msg.GetLevel(), req.Msg.IdempotencyKey)
+	return connect.NewResponse(&appsv1.AppendInstallationAuditLogEntryResponse{Entry: entry}), nil
+}
+
+type threadsGatewayServer struct {
+	gatewayv1connect.UnimplementedThreadsGatewayHandler
+	state *testState
+}
+
+func (s *threadsGatewayServer) CreateThread(_ context.Context, req *connect.Request[threadsv1.CreateThreadRequest]) (*connect.Response[threadsv1.CreateThreadResponse], error) {
+	thread := s.state.createThread(req.Msg.GetOrganizationId())
+	return connect.NewResponse(&threadsv1.CreateThreadResponse{Thread: thread}), nil
+}
+
+func (s *threadsGatewayServer) AddParticipant(_ context.Context, req *connect.Request[threadsv1.AddParticipantRequest]) (*connect.Response[threadsv1.AddParticipantResponse], error) {
+	participantID := ""
+	if req.Msg.GetParticipant() != nil {
+		participantID = req.Msg.GetParticipant().GetParticipantId()
+	}
+	if participantID == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, status.Error(codes.InvalidArgument, "participant_id required"))
+	}
+	thread, err := s.state.addParticipant(req.Msg.GetThreadId(), participantID, req.Msg.GetPassive())
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(&threadsv1.AddParticipantResponse{Thread: thread}), nil
+}
+
+func (s *threadsGatewayServer) SendMessage(_ context.Context, req *connect.Request[threadsv1.SendMessageRequest]) (*connect.Response[threadsv1.SendMessageResponse], error) {
+	message, err := s.state.sendMessage(req.Msg.GetThreadId(), req.Msg.GetSenderId(), req.Msg.GetBody(), req.Msg.GetFileIds())
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(&threadsv1.SendMessageResponse{Message: message}), nil
+}
+
+func (s *threadsGatewayServer) GetUnackedMessages(_ context.Context, req *connect.Request[threadsv1.GetUnackedMessagesRequest]) (*connect.Response[threadsv1.GetUnackedMessagesResponse], error) {
+	messages := s.state.listUnackedMessages(req.Msg.GetParticipantId())
+	return connect.NewResponse(&threadsv1.GetUnackedMessagesResponse{Messages: messages}), nil
+}
+
+func (s *threadsGatewayServer) AckMessages(_ context.Context, req *connect.Request[threadsv1.AckMessagesRequest]) (*connect.Response[threadsv1.AckMessagesResponse], error) {
+	s.state.ackMessages(req.Msg.GetParticipantId(), req.Msg.GetMessageIds())
+	return connect.NewResponse(&threadsv1.AckMessagesResponse{}), nil
+}
+
+type filesGatewayServer struct {
+	gatewayv1connect.UnimplementedFilesGatewayHandler
+	state *testState
+}
+
+func (s *filesGatewayServer) UploadFile(_ context.Context, stream *connect.ClientStream[filesv1.UploadFileRequest]) (*connect.Response[filesv1.UploadFileResponse], error) {
+	var metadata *filesv1.UploadFileMetadata
+	data := make([]byte, 0)
+	for stream.Receive() {
+		req := stream.Msg()
+		if meta := req.GetMetadata(); meta != nil {
+			metadata = meta
+			continue
+		}
+		if chunk := req.GetChunk(); chunk != nil {
+			data = append(data, chunk.GetData()...)
+		}
+	}
+	if err := stream.Err(); err != nil {
+		return nil, err
+	}
+	if metadata == nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, status.Error(codes.InvalidArgument, "metadata required"))
+	}
+	file := s.state.addFile(metadata, data)
+	return connect.NewResponse(&filesv1.UploadFileResponse{File: file}), nil
+}
+
+func (s *filesGatewayServer) GetFileMetadata(_ context.Context, req *connect.Request[filesv1.GetFileMetadataRequest]) (*connect.Response[filesv1.GetFileMetadataResponse], error) {
+	info, _, err := s.state.getFile(req.Msg.GetFileId())
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(&filesv1.GetFileMetadataResponse{File: info}), nil
+}
+
+func (s *filesGatewayServer) GetFileContent(_ context.Context, req *connect.Request[filesv1.GetFileContentRequest], stream *connect.ServerStream[filesv1.GetFileContentResponse]) error {
+	_, data, err := s.state.getFile(req.Msg.GetFileId())
+	if err != nil {
+		return err
+	}
+	return stream.Send(&filesv1.GetFileContentResponse{ChunkData: data})
+}
+
+type notificationsGatewayServer struct {
+	gatewayv1connect.UnimplementedNotificationsGatewayHandler
+	state *testState
+}
+
+func (s *notificationsGatewayServer) Subscribe(ctx context.Context, _ *connect.Request[notificationsv1.SubscribeRequest], stream *connect.ServerStream[notificationsv1.SubscribeResponse]) error {
+	id, ch := s.state.subscribeNotifications()
+	defer s.state.unsubscribeNotifications(id)
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case message, ok := <-ch:
+			if !ok {
+				return nil
+			}
+			if err := stream.Send(message); err != nil {
+				return err
+			}
+		}
+	}
+}

--- a/test/e2e/harness_state_test.go
+++ b/test/e2e/harness_state_test.go
@@ -1,0 +1,425 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"sync"
+
+	"github.com/google/uuid"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	appsv1 "github.com/agynio/telegram-connector/.gen/go/agynio/api/apps/v1"
+	filesv1 "github.com/agynio/telegram-connector/.gen/go/agynio/api/files/v1"
+	notificationsv1 "github.com/agynio/telegram-connector/.gen/go/agynio/api/notifications/v1"
+	organizationsv1 "github.com/agynio/telegram-connector/.gen/go/agynio/api/organizations/v1"
+	threadsv1 "github.com/agynio/telegram-connector/.gen/go/agynio/api/threads/v1"
+)
+
+type testState struct {
+	mu                 sync.Mutex
+	organizations      map[string]*organizationsv1.Organization
+	apps               map[string]*appsv1.App
+	installations      map[string]*appsv1.Installation
+	installationStatus map[string]string
+	auditLogs          map[string][]*appsv1.InstallationAuditLogEntry
+	threads            map[string]*threadState
+	messages           map[string]*messageState
+	files              map[string]*fileState
+	subscribers        map[int]chan *notificationsv1.SubscribeResponse
+	nextSubscriberID   int
+}
+
+type threadState struct {
+	thread       *threadsv1.Thread
+	participants map[string]*threadsv1.Participant
+	messages     []*messageState
+}
+
+type messageState struct {
+	message *threadsv1.Message
+	acked   map[string]struct{}
+}
+
+type fileState struct {
+	info *filesv1.FileInfo
+	data []byte
+}
+
+func newTestState() *testState {
+	return &testState{
+		organizations:      make(map[string]*organizationsv1.Organization),
+		apps:               make(map[string]*appsv1.App),
+		installations:      make(map[string]*appsv1.Installation),
+		installationStatus: make(map[string]string),
+		auditLogs:          make(map[string][]*appsv1.InstallationAuditLogEntry),
+		threads:            make(map[string]*threadState),
+		messages:           make(map[string]*messageState),
+		files:              make(map[string]*fileState),
+		subscribers:        make(map[int]chan *notificationsv1.SubscribeResponse),
+	}
+}
+
+func (s *testState) createOrganization(name string) *organizationsv1.Organization {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	org := &organizationsv1.Organization{
+		Id:        uuid.NewString(),
+		Name:      name,
+		CreatedAt: timestamppb.Now(),
+		UpdatedAt: timestamppb.Now(),
+	}
+	s.organizations[org.GetId()] = org
+	return cloneOrganization(org)
+}
+
+func (s *testState) deleteOrganization(id string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.organizations, id)
+}
+
+func (s *testState) createApp(req *appsv1.CreateAppRequest) (*appsv1.App, string, error) {
+	if req.GetOrganizationId() == "" {
+		return nil, "", status.Error(codes.InvalidArgument, "organization_id required")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	app := &appsv1.App{
+		Meta: &appsv1.EntityMeta{
+			Id:        uuid.NewString(),
+			CreatedAt: timestamppb.Now(),
+			UpdatedAt: timestamppb.Now(),
+		},
+		Slug:           req.GetSlug(),
+		Name:           req.GetName(),
+		Description:    req.GetDescription(),
+		OrganizationId: req.GetOrganizationId(),
+		Visibility:     req.GetVisibility(),
+		Permissions:    req.GetPermissions(),
+		IdentityId:     uuid.NewString(),
+	}
+	s.apps[app.GetMeta().GetId()] = app
+	serviceToken := "svc-" + uuid.NewString()
+	return cloneApp(app), serviceToken, nil
+}
+
+func (s *testState) deleteApp(id string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.apps, id)
+	for installationID, installation := range s.installations {
+		if installation.GetAppId() == id {
+			delete(s.installations, installationID)
+		}
+	}
+}
+
+func (s *testState) installApp(appID, organizationID string, config *structpb.Struct) (*appsv1.Installation, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.apps[appID]; !ok {
+		return nil, status.Error(codes.NotFound, "app not found")
+	}
+	for _, installation := range s.installations {
+		if installation.GetAppId() == appID && installation.GetOrganizationId() == organizationID {
+			return nil, status.Error(codes.AlreadyExists, "installation exists")
+		}
+	}
+	installation := &appsv1.Installation{
+		Meta: &appsv1.EntityMeta{
+			Id:        uuid.NewString(),
+			CreatedAt: timestamppb.Now(),
+			UpdatedAt: timestamppb.Now(),
+		},
+		AppId:          appID,
+		OrganizationId: organizationID,
+		Configuration:  config,
+	}
+	s.installations[installation.GetMeta().GetId()] = installation
+	return cloneInstallation(installation), nil
+}
+
+func (s *testState) updateInstallation(installationID string, config *structpb.Struct) (*appsv1.Installation, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	installation, ok := s.installations[installationID]
+	if !ok {
+		return nil, status.Error(codes.NotFound, "installation not found")
+	}
+	installation.Configuration = config
+	if installation.Meta != nil {
+		installation.Meta.UpdatedAt = timestamppb.Now()
+	}
+	s.installations[installationID] = installation
+	return cloneInstallation(installation), nil
+}
+
+func (s *testState) uninstallApp(installationID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.installations[installationID]; !ok {
+		return status.Error(codes.NotFound, "installation not found")
+	}
+	delete(s.installations, installationID)
+	return nil
+}
+
+func (s *testState) listInstallations(appID string) []*appsv1.Installation {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	installations := make([]*appsv1.Installation, 0, len(s.installations))
+	for _, installation := range s.installations {
+		if appID != "" && installation.GetAppId() != appID {
+			continue
+		}
+		installations = append(installations, cloneInstallation(installation))
+	}
+	return installations
+}
+
+func (s *testState) reportInstallationStatus(installationID, status string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	installation, ok := s.installations[installationID]
+	if !ok {
+		return statusError(codes.NotFound, "installation not found")
+	}
+	if status == "" {
+		installation.Status = nil
+	} else {
+		installation.Status = &status
+	}
+	s.installations[installationID] = installation
+	s.installationStatus[installationID] = status
+	return nil
+}
+
+func (s *testState) appendAudit(installationID, message string, level appsv1.InstallationAuditLogLevel, idempotencyKey *string) *appsv1.InstallationAuditLogEntry {
+	entries := s.auditLogs[installationID]
+	if idempotencyKey != nil {
+		for _, entry := range entries {
+			if entry.GetIdempotencyKey() == *idempotencyKey {
+				return cloneAudit(entry)
+			}
+		}
+	}
+	entry := &appsv1.InstallationAuditLogEntry{
+		Id:             uuid.NewString(),
+		InstallationId: installationID,
+		Message:        message,
+		Level:          level,
+		IdempotencyKey: idempotencyKey,
+		CreatedAt:      timestamppb.Now(),
+	}
+	s.auditLogs[installationID] = append(entries, entry)
+	return cloneAudit(entry)
+}
+
+func (s *testState) createThread(organizationID string) *threadsv1.Thread {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	thread := &threadsv1.Thread{
+		Id:             uuid.NewString(),
+		OrganizationId: organizationID,
+		Status:         threadsv1.ThreadStatus_THREAD_STATUS_ACTIVE,
+		CreatedAt:      timestamppb.Now(),
+		UpdatedAt:      timestamppb.Now(),
+	}
+	s.threads[thread.Id] = &threadState{
+		thread:       thread,
+		participants: make(map[string]*threadsv1.Participant),
+		messages:     make([]*messageState, 0),
+	}
+	return cloneThread(thread)
+}
+
+func (s *testState) addParticipant(threadID, participantID string, passive bool) (*threadsv1.Thread, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	threadState, ok := s.threads[threadID]
+	if !ok {
+		return nil, status.Error(codes.NotFound, "thread not found")
+	}
+	participant := &threadsv1.Participant{
+		Id:       participantID,
+		JoinedAt: timestamppb.Now(),
+		Passive:  passive,
+	}
+	threadState.participants[participantID] = participant
+	threadState.thread.Participants = participantsFromMap(threadState.participants)
+	threadState.thread.UpdatedAt = timestamppb.Now()
+	return cloneThread(threadState.thread), nil
+}
+
+func (s *testState) sendMessage(threadID, senderID, body string, fileIDs []string) (*threadsv1.Message, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	threadState, ok := s.threads[threadID]
+	if !ok {
+		return nil, status.Error(codes.NotFound, "thread not found")
+	}
+	message := &threadsv1.Message{
+		Id:        uuid.NewString(),
+		ThreadId:  threadID,
+		SenderId:  senderID,
+		Body:      body,
+		FileIds:   append([]string(nil), fileIDs...),
+		CreatedAt: timestamppb.Now(),
+	}
+	messageState := &messageState{message: message, acked: make(map[string]struct{})}
+	threadState.messages = append(threadState.messages, messageState)
+	s.messages[message.Id] = messageState
+	threadState.thread.MessageCount = int32(len(threadState.messages))
+	threadState.thread.UpdatedAt = timestamppb.Now()
+	return cloneMessage(message), nil
+}
+
+func (s *testState) listThreads(participantID string) []*threadsv1.Thread {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	threads := make([]*threadsv1.Thread, 0)
+	for _, threadState := range s.threads {
+		if participantID != "" {
+			if _, ok := threadState.participants[participantID]; !ok {
+				continue
+			}
+		}
+		threads = append(threads, cloneThread(threadState.thread))
+	}
+	return threads
+}
+
+func (s *testState) listMessages(threadID string) ([]*threadsv1.Message, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	threadState, ok := s.threads[threadID]
+	if !ok {
+		return nil, status.Error(codes.NotFound, "thread not found")
+	}
+	messages := make([]*threadsv1.Message, 0, len(threadState.messages))
+	for _, messageState := range threadState.messages {
+		messages = append(messages, cloneMessage(messageState.message))
+	}
+	return messages, nil
+}
+
+func (s *testState) listUnackedMessages(participantID string) []*threadsv1.Message {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	messages := make([]*threadsv1.Message, 0)
+	for _, messageState := range s.messages {
+		if _, ok := messageState.acked[participantID]; ok {
+			continue
+		}
+		messages = append(messages, cloneMessage(messageState.message))
+	}
+	return messages
+}
+
+func (s *testState) ackMessages(participantID string, messageIDs []string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, messageID := range messageIDs {
+		messageState, ok := s.messages[messageID]
+		if !ok {
+			continue
+		}
+		messageState.acked[participantID] = struct{}{}
+	}
+}
+
+func (s *testState) addFile(metadata *filesv1.UploadFileMetadata, data []byte) *filesv1.FileInfo {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	info := &filesv1.FileInfo{
+		Id:          uuid.NewString(),
+		Filename:    metadata.GetFilename(),
+		ContentType: metadata.GetContentType(),
+		SizeBytes:   int64(len(data)),
+		CreatedAt:   timestamppb.Now(),
+	}
+	s.files[info.Id] = &fileState{info: info, data: append([]byte(nil), data...)}
+	return cloneFile(info)
+}
+
+func (s *testState) getFile(fileID string) (*filesv1.FileInfo, []byte, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	fileState, ok := s.files[fileID]
+	if !ok {
+		return nil, nil, status.Error(codes.NotFound, "file not found")
+	}
+	return cloneFile(fileState.info), append([]byte(nil), fileState.data...), nil
+}
+
+func (s *testState) subscribeNotifications() (int, chan *notificationsv1.SubscribeResponse) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.nextSubscriberID++
+	id := s.nextSubscriberID
+	ch := make(chan *notificationsv1.SubscribeResponse, 10)
+	s.subscribers[id] = ch
+	return id, ch
+}
+
+func (s *testState) unsubscribeNotifications(id int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	ch, ok := s.subscribers[id]
+	if ok {
+		close(ch)
+		delete(s.subscribers, id)
+	}
+}
+
+func (s *testState) publishNotification(envelope *notificationsv1.NotificationEnvelope) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, ch := range s.subscribers {
+		ch <- &notificationsv1.SubscribeResponse{Envelope: envelope}
+	}
+}
+
+func cloneApp(app *appsv1.App) *appsv1.App {
+	return proto.Clone(app).(*appsv1.App)
+}
+
+func cloneInstallation(installation *appsv1.Installation) *appsv1.Installation {
+	return proto.Clone(installation).(*appsv1.Installation)
+}
+
+func cloneOrganization(org *organizationsv1.Organization) *organizationsv1.Organization {
+	return proto.Clone(org).(*organizationsv1.Organization)
+}
+
+func cloneThread(thread *threadsv1.Thread) *threadsv1.Thread {
+	return proto.Clone(thread).(*threadsv1.Thread)
+}
+
+func cloneMessage(message *threadsv1.Message) *threadsv1.Message {
+	return proto.Clone(message).(*threadsv1.Message)
+}
+
+func cloneFile(file *filesv1.FileInfo) *filesv1.FileInfo {
+	return proto.Clone(file).(*filesv1.FileInfo)
+}
+
+func cloneAudit(entry *appsv1.InstallationAuditLogEntry) *appsv1.InstallationAuditLogEntry {
+	return proto.Clone(entry).(*appsv1.InstallationAuditLogEntry)
+}
+
+func participantsFromMap(participants map[string]*threadsv1.Participant) []*threadsv1.Participant {
+	result := make([]*threadsv1.Participant, 0, len(participants))
+	for _, participant := range participants {
+		result = append(result, proto.Clone(participant).(*threadsv1.Participant))
+	}
+	return result
+}
+
+func statusError(code codes.Code, message string) error {
+	return status.Error(code, message)
+}

--- a/test/e2e/harness_state_test.go
+++ b/test/e2e/harness_state_test.go
@@ -199,6 +199,8 @@ func (s *testState) reportInstallationStatus(installationID, status string) erro
 }
 
 func (s *testState) appendAudit(installationID, message string, level appsv1.InstallationAuditLogLevel, idempotencyKey *string) *appsv1.InstallationAuditLogEntry {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	entries := s.auditLogs[installationID]
 	if idempotencyKey != nil {
 		for _, entry := range entries {

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -31,6 +31,7 @@ var (
 	threadsAddress       string
 	filesAddress         string
 	notificationsAddress string
+	localEnv             *localEnvironment
 
 	httpClient          *http.Client
 	appsClient          appsv1.AppsServiceClient
@@ -50,13 +51,30 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	connectorAddress = envOrDefault("TELEGRAM_CONNECTOR_ADDRESS", "telegram-connector:8080")
-	telegramMockAddress = envOrDefault("TELEGRAM_MOCK_ADDRESS", "telegram-mock:8443")
-	appsAddress = envOrDefault("APPS_ADDRESS", "apps:50051")
-	organizationsAddress = envOrDefault("ORGANIZATIONS_ADDRESS", "tenants:50051")
-	threadsAddress = envOrDefault("THREADS_ADDRESS", "threads:50051")
-	filesAddress = envOrDefault("FILES_ADDRESS", "files:50051")
-	notificationsAddress = envOrDefault("NOTIFICATIONS_ADDRESS", "notifications:50051")
+	useExternal := os.Getenv("E2E_EXTERNAL") == "true"
+	if useExternal {
+		connectorAddress = envOrDefault("TELEGRAM_CONNECTOR_ADDRESS", "telegram-connector:8080")
+		telegramMockAddress = envOrDefault("TELEGRAM_MOCK_ADDRESS", "telegram-mock:8443")
+		appsAddress = envOrDefault("APPS_ADDRESS", "apps:50051")
+		organizationsAddress = envOrDefault("ORGANIZATIONS_ADDRESS", "tenants:50051")
+		threadsAddress = envOrDefault("THREADS_ADDRESS", "threads:50051")
+		filesAddress = envOrDefault("FILES_ADDRESS", "files:50051")
+		notificationsAddress = envOrDefault("NOTIFICATIONS_ADDRESS", "notifications:50051")
+	} else {
+		env, err := startLocalEnvironment()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "e2e setup: local env: %v\n", err)
+			os.Exit(1)
+		}
+		localEnv = env
+		connectorAddress = env.connectorAddr
+		telegramMockAddress = env.telegramAddr
+		appsAddress = env.appsAddr
+		organizationsAddress = env.organizationsAddr
+		threadsAddress = env.threadsAddr
+		filesAddress = env.filesAddr
+		notificationsAddress = env.notificationsAddr
+	}
 
 	organizationID = os.Getenv("E2E_ORGANIZATION_ID")
 	appID = os.Getenv("E2E_APP_ID")
@@ -159,6 +177,9 @@ func TestMain(m *testing.M) {
 		fmt.Fprintf(os.Stderr, "e2e setup: reset telegram mock: %v\n", err)
 		os.Exit(1)
 	}
+	if localEnv != nil {
+		localEnv.StartConnector(appID, appIdentityID)
+	}
 
 	code := m.Run()
 
@@ -198,6 +219,9 @@ func TestMain(m *testing.M) {
 	}
 	if err := organizationsConn.Close(); err != nil {
 		fmt.Fprintf(os.Stderr, "e2e cleanup: close organizations conn: %v\n", err)
+	}
+	if localEnv != nil {
+		localEnv.Shutdown()
 	}
 
 	os.Exit(code)

--- a/test/e2e/memory_store_test.go
+++ b/test/e2e/memory_store_test.go
@@ -1,0 +1,159 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/agynio/telegram-connector/internal/store"
+)
+
+type memoryStore struct {
+	mu                 sync.Mutex
+	chatByTelegram     map[int64]store.ChatMapping
+	chatByThread       map[uuid.UUID]store.ChatMapping
+	installationStates map[uuid.UUID]store.InstallationState
+}
+
+func newMemoryStore() *memoryStore {
+	return &memoryStore{
+		chatByTelegram:     make(map[int64]store.ChatMapping),
+		chatByThread:       make(map[uuid.UUID]store.ChatMapping),
+		installationStates: make(map[uuid.UUID]store.InstallationState),
+	}
+}
+
+func (m *memoryStore) GetChatMapping(_ context.Context, _ uuid.UUID, telegramChatID int64) (store.ChatMapping, bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	mapping, ok := m.chatByTelegram[telegramChatID]
+	return mapping, ok, nil
+}
+
+func (m *memoryStore) GetChatMappingByThreadID(_ context.Context, _ uuid.UUID, threadID uuid.UUID) (store.ChatMapping, bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	mapping, ok := m.chatByThread[threadID]
+	return mapping, ok, nil
+}
+
+func (m *memoryStore) CreateChatMapping(_ context.Context, input store.ChatMappingInput) (store.ChatMapping, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	mapping, ok := m.chatByTelegram[input.TelegramChatID]
+	if !ok {
+		mapping = store.ChatMapping{
+			ID:             uuid.New(),
+			InstallationID: input.InstallationID,
+			TelegramChatID: input.TelegramChatID,
+			TelegramUserID: input.TelegramUserID,
+			ThreadID:       input.ThreadID,
+			CreatedAt:      time.Now().UTC(),
+		}
+	} else {
+		mapping.TelegramUserID = input.TelegramUserID
+		mapping.ThreadID = input.ThreadID
+	}
+	m.chatByTelegram[input.TelegramChatID] = mapping
+	m.chatByThread[input.ThreadID] = mapping
+	return mapping, nil
+}
+
+func (m *memoryStore) DeleteChatMapping(_ context.Context, _ uuid.UUID, telegramChatID int64) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	mapping, ok := m.chatByTelegram[telegramChatID]
+	if !ok {
+		return nil
+	}
+	delete(m.chatByTelegram, telegramChatID)
+	delete(m.chatByThread, mapping.ThreadID)
+	return nil
+}
+
+func (m *memoryStore) MarkChatBlocked(_ context.Context, _ uuid.UUID, telegramChatID int64) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	mapping, ok := m.chatByTelegram[telegramChatID]
+	if !ok {
+		return false, nil
+	}
+	if mapping.BlockedAt != nil {
+		return false, nil
+	}
+	now := time.Now().UTC()
+	mapping.BlockedAt = &now
+	m.chatByTelegram[telegramChatID] = mapping
+	m.chatByThread[mapping.ThreadID] = mapping
+	return true, nil
+}
+
+func (m *memoryStore) ClearChatBlocked(_ context.Context, _ uuid.UUID, telegramChatID int64) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	mapping, ok := m.chatByTelegram[telegramChatID]
+	if !ok {
+		return false, nil
+	}
+	if mapping.BlockedAt == nil {
+		return false, nil
+	}
+	mapping.BlockedAt = nil
+	m.chatByTelegram[telegramChatID] = mapping
+	m.chatByThread[mapping.ThreadID] = mapping
+	return true, nil
+}
+
+func (m *memoryStore) CountActiveChats(_ context.Context, installationID uuid.UUID) (int64, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var count int64
+	for _, mapping := range m.chatByTelegram {
+		if mapping.InstallationID != installationID {
+			continue
+		}
+		if mapping.BlockedAt == nil {
+			count++
+		}
+	}
+	return count, nil
+}
+
+func (m *memoryStore) CountBlockedChats(_ context.Context, installationID uuid.UUID) (int64, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var count int64
+	for _, mapping := range m.chatByTelegram {
+		if mapping.InstallationID != installationID {
+			continue
+		}
+		if mapping.BlockedAt != nil {
+			count++
+		}
+	}
+	return count, nil
+}
+
+func (m *memoryStore) UpsertInstallationState(_ context.Context, installationID uuid.UUID, lastUpdateID int64) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.installationStates[installationID] = store.InstallationState{
+		LastUpdateID: lastUpdateID,
+		UpdatedAt:    time.Now().UTC(),
+	}
+	return nil
+}
+
+func (m *memoryStore) GetInstallationState(_ context.Context, installationID uuid.UUID) (store.InstallationState, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	state, ok := m.installationStates[installationID]
+	if !ok {
+		return store.InstallationState{}, nil
+	}
+	return state, nil
+}

--- a/test/e2e/telegram_mock_server_test.go
+++ b/test/e2e/telegram_mock_server_test.go
@@ -1,0 +1,638 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/agynio/telegram-connector/internal/telegram"
+)
+
+const telegramMockPollInterval = 200 * time.Millisecond
+
+type telegramMockHandler struct {
+	mu     sync.Mutex
+	tokens map[string]*telegramTokenState
+}
+
+type telegramTokenState struct {
+	updates    []telegram.Update
+	files      map[string]telegramFile
+	sends      []telegramSend
+	sendErrors []sendError
+}
+
+type telegramFile struct {
+	fileID      string
+	filePath    string
+	data        []byte
+	contentType string
+}
+
+type telegramSend struct {
+	method      string
+	chatID      int64
+	text        string
+	url         string
+	filename    string
+	contentType string
+	data        []byte
+	statusCode  int
+	errorCode   int
+	description string
+	retryAfter  time.Duration
+}
+
+type sendError struct {
+	statusCode  int
+	errorCode   int
+	description string
+	retryAfter  time.Duration
+	method      string
+}
+
+func startTelegramMockServer() (string, *http.Server, error) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return "", nil, err
+	}
+	handler := newTelegramMockHandler()
+	server := &http.Server{Handler: handler}
+	go server.Serve(listener)
+	return listener.Addr().String(), server, nil
+}
+
+func newTelegramMockHandler() *telegramMockHandler {
+	return &telegramMockHandler{tokens: make(map[string]*telegramTokenState)}
+}
+
+func (s *telegramMockHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch {
+	case strings.HasPrefix(r.URL.Path, "/_control/"):
+		s.handleControl(w, r)
+	case strings.HasPrefix(r.URL.Path, "/file/"):
+		s.handleFileDownload(w, r)
+	case strings.HasPrefix(r.URL.Path, "/bot"):
+		s.handleBotAPI(w, r)
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func (s *telegramMockHandler) handleControl(w http.ResponseWriter, r *http.Request) {
+	switch r.URL.Path {
+	case "/_control/healthz":
+		if r.Method != http.MethodGet {
+			methodNotAllowed(w, r)
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+	case "/_control/enqueue":
+		if r.Method != http.MethodPost {
+			methodNotAllowed(w, r)
+			return
+		}
+		var req enqueueRequest
+		if err := decodeJSON(r.Body, &req); err != nil {
+			writeJSON(w, http.StatusBadRequest, errorResponse(err))
+			return
+		}
+		if req.Token == "" {
+			writeJSON(w, http.StatusBadRequest, errorResponse(fmt.Errorf("token is required")))
+			return
+		}
+		if len(req.Updates) == 0 {
+			writeJSON(w, http.StatusBadRequest, errorResponse(fmt.Errorf("updates are required")))
+			return
+		}
+		s.enqueueUpdates(req.Token, req.Updates)
+		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+	case "/_control/reset":
+		if r.Method != http.MethodPost {
+			methodNotAllowed(w, r)
+			return
+		}
+		var req resetRequest
+		if err := decodeJSON(r.Body, &req); err != nil {
+			writeJSON(w, http.StatusBadRequest, errorResponse(err))
+			return
+		}
+		s.resetState(req.Token)
+		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+	case "/_control/set-file":
+		if r.Method != http.MethodPost {
+			methodNotAllowed(w, r)
+			return
+		}
+		var req setFileRequest
+		if err := decodeJSON(r.Body, &req); err != nil {
+			writeJSON(w, http.StatusBadRequest, errorResponse(err))
+			return
+		}
+		if req.Token == "" || req.FileID == "" || req.FilePath == "" {
+			writeJSON(w, http.StatusBadRequest, errorResponse(fmt.Errorf("token, file_id, and file_path are required")))
+			return
+		}
+		data, err := base64.StdEncoding.DecodeString(req.DataBase64)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, errorResponse(fmt.Errorf("invalid data_base64: %w", err)))
+			return
+		}
+		s.setFile(req.Token, telegramFile{
+			fileID:      req.FileID,
+			filePath:    req.FilePath,
+			data:        data,
+			contentType: req.ContentType,
+		})
+		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+	case "/_control/set-send-error":
+		if r.Method != http.MethodPost {
+			methodNotAllowed(w, r)
+			return
+		}
+		var req setSendErrorRequest
+		if err := decodeJSON(r.Body, &req); err != nil {
+			writeJSON(w, http.StatusBadRequest, errorResponse(err))
+			return
+		}
+		if req.Token == "" {
+			writeJSON(w, http.StatusBadRequest, errorResponse(fmt.Errorf("token is required")))
+			return
+		}
+		s.enqueueSendError(req.Token, sendError{
+			statusCode:  req.StatusCode,
+			errorCode:   req.ErrorCode,
+			description: req.Description,
+			retryAfter:  time.Duration(req.RetryAfterSeconds) * time.Second,
+			method:      req.Method,
+		})
+		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+	case "/_control/sent-messages":
+		if r.Method != http.MethodGet {
+			methodNotAllowed(w, r)
+			return
+		}
+		token := r.URL.Query().Get("token")
+		if token == "" {
+			writeJSON(w, http.StatusBadRequest, errorResponse(fmt.Errorf("token is required")))
+			return
+		}
+		messages := s.sentMessages(token)
+		writeJSON(w, http.StatusOK, map[string]any{"messages": messages})
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func (s *telegramMockHandler) handleFileDownload(w http.ResponseWriter, r *http.Request) {
+	token, filePath, ok := parseFilePath(r.URL.Path)
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	if r.Method != http.MethodGet {
+		methodNotAllowed(w, r)
+		return
+	}
+	file, ok := s.fileByPath(token, filePath)
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	if file.contentType != "" {
+		w.Header().Set("Content-Type", file.contentType)
+	}
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(file.data)
+}
+
+func (s *telegramMockHandler) handleBotAPI(w http.ResponseWriter, r *http.Request) {
+	token, method, ok := parseBotPath(r.URL.Path)
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	switch method {
+	case "getUpdates":
+		s.handleGetUpdates(w, r, token)
+	case "getFile":
+		s.handleGetFile(w, r, token)
+	case "sendMessage":
+		s.handleSendMessage(w, r, token)
+	case "sendPhoto":
+		s.handleSendMedia(w, r, token, "sendPhoto", "photo")
+	case "sendDocument":
+		s.handleSendMedia(w, r, token, "sendDocument", "document")
+	case "sendAudio":
+		s.handleSendMedia(w, r, token, "sendAudio", "audio")
+	case "sendVideo":
+		s.handleSendMedia(w, r, token, "sendVideo", "video")
+	case "sendVoice":
+		s.handleSendMedia(w, r, token, "sendVoice", "voice")
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func (s *telegramMockHandler) handleGetUpdates(w http.ResponseWriter, r *http.Request, token string) {
+	if r.Method != http.MethodPost {
+		methodNotAllowed(w, r)
+		return
+	}
+	var req struct {
+		Offset  int64 `json:"offset"`
+		Timeout int   `json:"timeout"`
+		Limit   int   `json:"limit"`
+	}
+	if err := decodeJSON(r.Body, &req); err != nil {
+		writeTelegramError(w, http.StatusBadRequest, http.StatusBadRequest, err.Error(), 0)
+		return
+	}
+	if req.Timeout < 0 {
+		req.Timeout = 0
+	}
+	if req.Limit < 0 {
+		req.Limit = 0
+	}
+	updates := s.waitForUpdates(r.Context(), token, req.Offset, req.Limit, time.Duration(req.Timeout)*time.Second)
+	if r.Context().Err() != nil {
+		return
+	}
+	writeTelegramOK(w, updates)
+}
+
+func (s *telegramMockHandler) waitForUpdates(ctx context.Context, token string, offset int64, limit int, timeout time.Duration) []telegram.Update {
+	if timeout <= 0 {
+		return s.consumeUpdates(token, offset, limit)
+	}
+	deadline := time.Now().Add(timeout)
+	for {
+		updates := s.consumeUpdates(token, offset, limit)
+		if len(updates) > 0 {
+			return updates
+		}
+		if time.Now().After(deadline) {
+			return nil
+		}
+		wait := telegramMockPollInterval
+		if remaining := time.Until(deadline); remaining < wait {
+			wait = remaining
+		}
+		timer := time.NewTimer(wait)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return nil
+		case <-timer.C:
+		}
+	}
+}
+
+func (s *telegramMockHandler) handleGetFile(w http.ResponseWriter, r *http.Request, token string) {
+	if r.Method != http.MethodPost {
+		methodNotAllowed(w, r)
+		return
+	}
+	var req struct {
+		FileID string `json:"file_id"`
+	}
+	if err := decodeJSON(r.Body, &req); err != nil {
+		writeTelegramError(w, http.StatusBadRequest, http.StatusBadRequest, err.Error(), 0)
+		return
+	}
+	if req.FileID == "" {
+		writeTelegramError(w, http.StatusBadRequest, http.StatusBadRequest, "file_id is required", 0)
+		return
+	}
+	file, ok := s.fileByID(token, req.FileID)
+	if !ok {
+		writeTelegramError(w, http.StatusNotFound, http.StatusNotFound, "file not found", 0)
+		return
+	}
+	writeTelegramOK(w, map[string]any{
+		"file_id":   file.fileID,
+		"file_path": file.filePath,
+		"file_size": len(file.data),
+	})
+}
+
+func (s *telegramMockHandler) handleSendMessage(w http.ResponseWriter, r *http.Request, token string) {
+	if r.Method != http.MethodPost {
+		methodNotAllowed(w, r)
+		return
+	}
+	var req struct {
+		ChatID int64  `json:"chat_id"`
+		Text   string `json:"text"`
+	}
+	if err := decodeJSON(r.Body, &req); err != nil {
+		writeTelegramError(w, http.StatusBadRequest, http.StatusBadRequest, err.Error(), 0)
+		return
+	}
+	s.respondSend(w, token, telegramSend{method: "sendMessage", chatID: req.ChatID, text: req.Text})
+}
+
+func (s *telegramMockHandler) handleSendMedia(w http.ResponseWriter, r *http.Request, token, method, field string) {
+	if r.Method != http.MethodPost {
+		methodNotAllowed(w, r)
+		return
+	}
+	if strings.HasPrefix(r.Header.Get("Content-Type"), "application/json") {
+		send, err := parseJSONMedia(r.Body, method, field)
+		if err != nil {
+			writeTelegramError(w, http.StatusBadRequest, http.StatusBadRequest, err.Error(), 0)
+			return
+		}
+		s.respondSend(w, token, send)
+		return
+	}
+	send, err := parseMultipartMedia(r, method, field)
+	if err != nil {
+		writeTelegramError(w, http.StatusBadRequest, http.StatusBadRequest, err.Error(), 0)
+		return
+	}
+	s.respondSend(w, token, send)
+}
+
+func (s *telegramMockHandler) respondSend(w http.ResponseWriter, token string, send telegramSend) {
+	if send.method == "" {
+		writeTelegramError(w, http.StatusBadRequest, http.StatusBadRequest, "method is required", 0)
+		return
+	}
+	if send.chatID == 0 {
+		writeTelegramError(w, http.StatusBadRequest, http.StatusBadRequest, "chat_id is required", 0)
+		return
+	}
+	if sendErr, ok := s.popSendError(token, send.method); ok {
+		send.statusCode = sendErr.statusCode
+		send.errorCode = sendErr.errorCode
+		send.description = sendErr.description
+		send.retryAfter = sendErr.retryAfter
+		s.recordSend(token, send)
+		writeTelegramError(w, sendErr.statusCode, sendErr.errorCode, sendErr.description, sendErr.retryAfter)
+		return
+	}
+	send.statusCode = http.StatusOK
+	s.recordSend(token, send)
+	writeTelegramOK(w, map[string]any{"message_id": 1})
+}
+
+func (s *telegramMockHandler) enqueueUpdates(token string, updates []telegram.Update) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	state := s.ensureTokenState(token)
+	state.updates = append(state.updates, updates...)
+}
+
+func (s *telegramMockHandler) resetState(token string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if token == "" {
+		s.tokens = make(map[string]*telegramTokenState)
+		return
+	}
+	state, ok := s.tokens[token]
+	if !ok {
+		return
+	}
+	state.updates = nil
+	state.files = make(map[string]telegramFile)
+	state.sends = nil
+	state.sendErrors = nil
+}
+
+func (s *telegramMockHandler) setFile(token string, file telegramFile) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	state := s.ensureTokenState(token)
+	state.files[file.fileID] = file
+}
+
+func (s *telegramMockHandler) enqueueSendError(token string, err sendError) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	state := s.ensureTokenState(token)
+	state.sendErrors = append(state.sendErrors, err)
+}
+
+func (s *telegramMockHandler) consumeUpdates(token string, offset int64, limit int) []telegram.Update {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	state := s.ensureTokenState(token)
+	if offset > 0 {
+		filtered := make([]telegram.Update, 0, len(state.updates))
+		for _, update := range state.updates {
+			if update.UpdateID >= offset {
+				filtered = append(filtered, update)
+			}
+		}
+		state.updates = filtered
+	}
+	if limit <= 0 || limit > len(state.updates) {
+		limit = len(state.updates)
+	}
+	updates := make([]telegram.Update, limit)
+	copy(updates, state.updates[:limit])
+	return updates
+}
+
+func (s *telegramMockHandler) fileByID(token, fileID string) (telegramFile, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	state := s.ensureTokenState(token)
+	file, ok := state.files[fileID]
+	return file, ok
+}
+
+func (s *telegramMockHandler) fileByPath(token, filePath string) (telegramFile, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	state := s.ensureTokenState(token)
+	for _, file := range state.files {
+		if file.filePath == filePath {
+			return file, true
+		}
+	}
+	return telegramFile{}, false
+}
+
+func (s *telegramMockHandler) sentMessages(token string) []sentMessage {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	state := s.ensureTokenState(token)
+	messages := make([]sentMessage, 0, len(state.sends))
+	for _, send := range state.sends {
+		msg := sentMessage{
+			Method:            send.method,
+			ChatID:            send.chatID,
+			Text:              send.text,
+			URL:               send.url,
+			Filename:          send.filename,
+			ContentType:       send.contentType,
+			StatusCode:        send.statusCode,
+			ErrorCode:         send.errorCode,
+			Description:       send.description,
+			RetryAfterSeconds: int(send.retryAfter.Seconds()),
+		}
+		if len(send.data) > 0 {
+			msg.DataBase64 = base64.StdEncoding.EncodeToString(send.data)
+		}
+		messages = append(messages, msg)
+	}
+	return messages
+}
+
+func (s *telegramMockHandler) recordSend(token string, send telegramSend) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	state := s.ensureTokenState(token)
+	state.sends = append(state.sends, send)
+}
+
+func (s *telegramMockHandler) popSendError(token, method string) (sendError, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	state := s.ensureTokenState(token)
+	for idx, err := range state.sendErrors {
+		if err.method == "" || err.method == method {
+			state.sendErrors = append(state.sendErrors[:idx], state.sendErrors[idx+1:]...)
+			return err, true
+		}
+	}
+	return sendError{}, false
+}
+
+func (s *telegramMockHandler) ensureTokenState(token string) *telegramTokenState {
+	state, ok := s.tokens[token]
+	if !ok {
+		state = &telegramTokenState{files: make(map[string]telegramFile)}
+		s.tokens[token] = state
+	}
+	return state
+}
+
+func parseBotPath(path string) (string, string, bool) {
+	if !strings.HasPrefix(path, "/bot") {
+		return "", "", false
+	}
+	rest := strings.TrimPrefix(path, "/bot")
+	parts := strings.SplitN(rest, "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", false
+	}
+	return parts[0], parts[1], true
+}
+
+func parseFilePath(path string) (string, string, bool) {
+	if !strings.HasPrefix(path, "/file/bot") {
+		return "", "", false
+	}
+	rest := strings.TrimPrefix(path, "/file/bot")
+	parts := strings.SplitN(rest, "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", false
+	}
+	return parts[0], parts[1], true
+}
+
+func parseJSONMedia(body io.Reader, method, field string) (telegramSend, error) {
+	var payload map[string]any
+	if err := json.NewDecoder(body).Decode(&payload); err != nil {
+		return telegramSend{}, err
+	}
+	chatValue, ok := payload["chat_id"]
+	if !ok {
+		return telegramSend{}, fmt.Errorf("chat_id is required")
+	}
+	chatID, err := floatToInt64(chatValue)
+	if err != nil {
+		return telegramSend{}, err
+	}
+	urlValue, _ := payload[field].(string)
+	return telegramSend{method: method, chatID: chatID, url: urlValue}, nil
+}
+
+func parseMultipartMedia(r *http.Request, method, field string) (telegramSend, error) {
+	if err := r.ParseMultipartForm(10 << 20); err != nil {
+		return telegramSend{}, err
+	}
+	chatIDValue := r.FormValue("chat_id")
+	if chatIDValue == "" {
+		return telegramSend{}, fmt.Errorf("chat_id is required")
+	}
+	chatID, err := strconv.ParseInt(chatIDValue, 10, 64)
+	if err != nil {
+		return telegramSend{}, err
+	}
+	file, header, err := r.FormFile(field)
+	if err != nil {
+		return telegramSend{}, err
+	}
+	defer file.Close()
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return telegramSend{}, err
+	}
+	return telegramSend{
+		method:      method,
+		chatID:      chatID,
+		filename:    header.Filename,
+		contentType: header.Header.Get("Content-Type"),
+		data:        data,
+	}, nil
+}
+
+func floatToInt64(value any) (int64, error) {
+	number, ok := value.(float64)
+	if !ok {
+		return 0, fmt.Errorf("invalid chat_id type")
+	}
+	return int64(number), nil
+}
+
+func decodeJSON(body io.Reader, target any) error {
+	decoder := json.NewDecoder(body)
+	decoder.DisallowUnknownFields()
+	return decoder.Decode(target)
+}
+
+func writeTelegramOK(w http.ResponseWriter, result any) {
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "result": result})
+}
+
+func writeTelegramError(w http.ResponseWriter, status, errorCode int, description string, retryAfter time.Duration) {
+	payload := map[string]any{
+		"ok":          false,
+		"error_code":  errorCode,
+		"description": description,
+	}
+	if retryAfter > 0 {
+		payload["parameters"] = map[string]any{"retry_after": int(retryAfter.Seconds())}
+		w.Header().Set("Retry-After", strconv.Itoa(int(retryAfter.Seconds())))
+	}
+	writeJSON(w, status, payload)
+}
+
+func writeJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(payload)
+}
+
+func methodNotAllowed(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusMethodNotAllowed, errorResponse(fmt.Errorf("method %s not allowed", r.Method)))
+}
+
+func errorResponse(err error) map[string]string {
+	return map[string]string{"error": err.Error()}
+}


### PR DESCRIPTION
## Summary
- implement per-installation status reporting and audit log emission
- add local in-memory e2e harness for gateway/apps/threads/files/notifications
- update inbound/outbound flows and tests for status/audit transitions

## Testing
- buf generate
- go test ./...
- go vet ./...
- go test -tags e2e ./test/e2e

Refs #9