### PR TITLE
fix(inbound): handle media content types

### DIFF
--- a/internal/connector/audit.go
+++ b/internal/connector/audit.go
@@ -31,6 +31,7 @@ const (
 	auditEventOutboundFailed       = "outbound_delivery_failed"
 	auditEventBotBlocked           = "bot_blocked_by_user"
 	auditEventBotUnblocked         = "bot_unblocked_by_user"
+	auditEventAttachmentSkipped    = "attachment_skipped"
 )
 
 type auditEvent struct {

--- a/internal/connector/content_type.go
+++ b/internal/connector/content_type.go
@@ -9,6 +9,7 @@ import (
 
 const photoFallbackContentType = "image/jpeg"
 
+// Keep in sync with agynio/files internal/filetype allowlist.
 var allowedContentTypePrefixes = []string{
 	"image/",
 	"text/",

--- a/internal/connector/content_type.go
+++ b/internal/connector/content_type.go
@@ -1,0 +1,148 @@
+package connector
+
+import (
+	"fmt"
+	"mime"
+	"path"
+	"strings"
+)
+
+const photoFallbackContentType = "image/jpeg"
+
+var allowedContentTypePrefixes = []string{
+	"image/",
+	"text/",
+	"video/",
+	"audio/",
+	"application/pdf",
+	"application/msword",
+	"application/vnd.openxmlformats-officedocument",
+	"application/vnd.ms-excel",
+	"application/vnd.ms-powerpoint",
+	"application/json",
+	"application/xml",
+	"application/zip",
+	"application/gzip",
+	"application/x-tar",
+}
+
+var contentTypeAliases = map[string]string{
+	"application/x-zip-compressed": "application/zip",
+	"application/x-gzip":           "application/gzip",
+}
+
+type contentTypeCandidate struct {
+	source     string
+	raw        string
+	normalized string
+}
+
+func buildContentTypeCandidates(updateMime, sniffed, extension, header string) []contentTypeCandidate {
+	return []contentTypeCandidate{
+		newContentTypeCandidate("telegram_mime", updateMime),
+		newContentTypeCandidate("sniffed", sniffed),
+		newContentTypeCandidate("extension", extension),
+		newContentTypeCandidate("header", header),
+	}
+}
+
+func newContentTypeCandidate(source, raw string) contentTypeCandidate {
+	trimmed := strings.TrimSpace(raw)
+	normalized, ok := normalizeContentType(trimmed)
+	if !ok {
+		normalized = ""
+	}
+	return contentTypeCandidate{source: source, raw: trimmed, normalized: normalized}
+}
+
+func normalizeContentType(raw string) (string, bool) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return "", false
+	}
+	mediaType, _, err := mime.ParseMediaType(trimmed)
+	if err != nil {
+		return "", false
+	}
+	mediaType = strings.ToLower(mediaType)
+	if alias, ok := contentTypeAliases[mediaType]; ok {
+		mediaType = alias
+	}
+	return mediaType, true
+}
+
+func selectAllowedContentTypes(candidates []contentTypeCandidate, requireImage bool) []string {
+	allowed := make([]string, 0, len(candidates))
+	seen := make(map[string]struct{})
+	for _, candidate := range candidates {
+		contentType := candidate.normalized
+		if contentType == "" {
+			continue
+		}
+		if isGenericContentType(contentType) {
+			continue
+		}
+		if requireImage && !strings.HasPrefix(contentType, "image/") {
+			continue
+		}
+		if !isAllowedContentType(contentType) {
+			continue
+		}
+		if _, ok := seen[contentType]; ok {
+			continue
+		}
+		seen[contentType] = struct{}{}
+		allowed = append(allowed, contentType)
+	}
+	if requireImage && len(allowed) == 0 {
+		allowed = append(allowed, photoFallbackContentType)
+	}
+	return allowed
+}
+
+func isAllowedContentType(contentType string) bool {
+	for _, prefix := range allowedContentTypePrefixes {
+		if strings.HasPrefix(contentType, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func isGenericContentType(contentType string) bool {
+	return contentType == "application/octet-stream"
+}
+
+func formatContentTypeCandidates(candidates []contentTypeCandidate) string {
+	parts := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		raw := strings.TrimSpace(candidate.raw)
+		normalized := candidate.normalized
+		if raw == "" && normalized == "" {
+			continue
+		}
+		value := normalized
+		if normalized == "" {
+			value = fmt.Sprintf("invalid(%s)", raw)
+		} else if raw != "" && strings.ToLower(raw) != normalized {
+			value = fmt.Sprintf("%s (%s)", normalized, raw)
+		}
+		if candidate.source != "" {
+			parts = append(parts, fmt.Sprintf("%s=%s", candidate.source, value))
+		} else {
+			parts = append(parts, value)
+		}
+	}
+	return strings.Join(parts, ", ")
+}
+
+func extensionContentType(filePath, filename string) string {
+	extension := path.Ext(filePath)
+	if extension == "" {
+		extension = path.Ext(filename)
+	}
+	if extension == "" {
+		return ""
+	}
+	return mime.TypeByExtension(strings.ToLower(extension))
+}

--- a/internal/connector/content_type.go
+++ b/internal/connector/content_type.go
@@ -137,6 +137,18 @@ func formatContentTypeCandidates(candidates []contentTypeCandidate) string {
 	return strings.Join(parts, ", ")
 }
 
+func bestContentTypeDetail(candidates []contentTypeCandidate) string {
+	for _, candidate := range candidates {
+		if candidate.normalized != "" {
+			return candidate.normalized
+		}
+		if strings.TrimSpace(candidate.raw) != "" {
+			return strings.TrimSpace(candidate.raw)
+		}
+	}
+	return ""
+}
+
 func extensionContentType(filePath, filename string) string {
 	extension := path.Ext(filePath)
 	if extension == "" {

--- a/internal/connector/content_type_test.go
+++ b/internal/connector/content_type_test.go
@@ -1,0 +1,146 @@
+package connector
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	appsv1 "github.com/agynio/telegram-connector/.gen/go/agynio/api/apps/v1"
+)
+
+func TestSelectAllowedContentTypesPrefersTelegramMime(t *testing.T) {
+	candidates := buildContentTypeCandidates("image/png", "", "", "application/octet-stream")
+	allowed := selectAllowedContentTypes(candidates, false)
+	if len(allowed) != 1 || allowed[0] != "image/png" {
+		t.Fatalf("expected image/png, got %v", allowed)
+	}
+}
+
+func TestSelectAllowedContentTypesUsesSniffedWhenTelegramMissing(t *testing.T) {
+	candidates := buildContentTypeCandidates("", "image/jpeg", "", "application/octet-stream")
+	allowed := selectAllowedContentTypes(candidates, false)
+	if len(allowed) != 1 || allowed[0] != "image/jpeg" {
+		t.Fatalf("expected image/jpeg, got %v", allowed)
+	}
+}
+
+func TestSelectAllowedContentTypesAliases(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{name: "zip", raw: "application/x-zip-compressed", want: "application/zip"},
+		{name: "gzip", raw: "application/x-gzip", want: "application/gzip"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			candidates := buildContentTypeCandidates(tt.raw, "", "", "")
+			allowed := selectAllowedContentTypes(candidates, false)
+			if len(allowed) != 1 || allowed[0] != tt.want {
+				t.Fatalf("expected %s, got %v", tt.want, allowed)
+			}
+		})
+	}
+}
+
+func TestUploadTelegramFileSkipsDisallowedContentTypes(t *testing.T) {
+	token := "token"
+	fileID := "file-123"
+	filePath := "files/" + fileID + ".bin"
+	data := bytes.Repeat([]byte{0x00}, 512)
+	if detected := http.DetectContentType(data); detected != "application/octet-stream" {
+		t.Fatalf("expected sniffed octet-stream, got %s", detected)
+	}
+	server := newTelegramFileServer(t, token, fileID, filePath, "application/octet-stream", data)
+	defer server.Close()
+
+	installationID := uuid.New()
+	auditCalled := false
+	gatewayStub := &stubGateway{
+		t: t,
+		appendAuditFn: func(_ context.Context, installationArg, message string, level appsv1.InstallationAuditLogLevel, idempotencyKey string) error {
+			auditCalled = true
+			if installationArg != installationID.String() {
+				t.Fatalf("expected installation %s, got %s", installationID, installationArg)
+			}
+			if level != appsv1.InstallationAuditLogLevel_INSTALLATION_AUDIT_LOG_LEVEL_WARNING {
+				t.Fatalf("expected warning level, got %v", level)
+			}
+			if !strings.Contains(message, auditEventAttachmentSkipped) {
+				t.Fatalf("expected audit event %s, got %s", auditEventAttachmentSkipped, message)
+			}
+			if !strings.Contains(message, fileID) {
+				t.Fatalf("expected file id in message, got %s", message)
+			}
+			if !strings.Contains(message, "application/octet-stream") {
+				t.Fatalf("expected content types in message, got %s", message)
+			}
+			if strings.TrimSpace(idempotencyKey) == "" {
+				t.Fatal("expected idempotency key")
+			}
+			return nil
+		},
+	}
+	storeStub := &stubStore{t: t}
+	worker := newInstallationWorker(Installation{
+		ID:             installationID,
+		OrganizationID: uuid.New(),
+		BotToken:       token,
+		AgentID:        uuid.New(),
+	}, storeStub, gatewayStub, server.URL, time.Second)
+
+	uploadedID, err := worker.uploadTelegramFile(context.Background(), fileID, "", "", false)
+	if err != nil {
+		t.Fatalf("uploadTelegramFile returned error: %v", err)
+	}
+	if uploadedID != "" {
+		t.Fatalf("expected no upload id, got %s", uploadedID)
+	}
+	if !auditCalled {
+		t.Fatal("expected audit log call")
+	}
+}
+
+func newTelegramFileServer(t *testing.T, token, fileID, filePath, contentType string, data []byte) *httptest.Server {
+	t.Helper()
+	getFilePath := "/bot" + token + "/getFile"
+	filePrefix := "/file/bot" + token + "/"
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == getFilePath:
+			resp := map[string]any{
+				"ok": true,
+				"result": map[string]any{
+					"file_id":   fileID,
+					"file_path": filePath,
+					"file_size": len(data),
+				},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(resp)
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, filePrefix):
+			if strings.TrimPrefix(r.URL.Path, filePrefix) != filePath {
+				http.NotFound(w, r)
+				return
+			}
+			if contentType != "" {
+				w.Header().Set("Content-Type", contentType)
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(data)
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	return httptest.NewServer(handler)
+}

--- a/internal/connector/content_type_test.go
+++ b/internal/connector/content_type_test.go
@@ -97,12 +97,21 @@ func TestUploadTelegramFileSkipsDisallowedContentTypes(t *testing.T) {
 		AgentID:        uuid.New(),
 	}, storeStub, gatewayStub, server.URL, time.Second)
 
-	uploadedID, err := worker.uploadTelegramFile(context.Background(), fileID, "", "", false)
+	result, err := worker.uploadTelegramFile(context.Background(), fileID, "", "", false)
 	if err != nil {
 		t.Fatalf("uploadTelegramFile returned error: %v", err)
 	}
-	if uploadedID != "" {
-		t.Fatalf("expected no upload id, got %s", uploadedID)
+	if result.fileID != "" {
+		t.Fatalf("expected no upload id, got %s", result.fileID)
+	}
+	if !strings.Contains(result.skipMarker, "attachment skipped") {
+		t.Fatalf("expected skip marker, got %s", result.skipMarker)
+	}
+	if !strings.Contains(result.skipMarker, "size=512") {
+		t.Fatalf("expected size detail, got %s", result.skipMarker)
+	}
+	if !strings.Contains(result.skipMarker, "content_type=application/octet-stream") {
+		t.Fatalf("expected content type detail, got %s", result.skipMarker)
 	}
 	if !auditCalled {
 		t.Fatal("expected audit log call")

--- a/internal/connector/inbound.go
+++ b/internal/connector/inbound.go
@@ -313,39 +313,39 @@ func (w *installationWorker) buildInboundMessage(ctx context.Context, message *t
 	caption := strings.TrimSpace(message.Caption)
 	if len(message.Photo) > 0 {
 		photo := largestPhoto(message.Photo)
-		fileID, err := w.uploadTelegramFile(ctx, photo.FileID, "photo", "image/jpeg", true)
+		result, err := w.uploadTelegramFile(ctx, photo.FileID, "photo", "image/jpeg", true)
 		if err != nil {
 			return "", nil, err
 		}
-		return caption, fileIDsOrNil(fileID), nil
+		return applyAttachmentMarker(caption, result), fileIDsOrNil(result.fileID), nil
 	}
 	if message.Document != nil {
-		fileID, err := w.uploadTelegramFile(ctx, message.Document.FileID, message.Document.FileName, message.Document.MimeType, false)
+		result, err := w.uploadTelegramFile(ctx, message.Document.FileID, message.Document.FileName, message.Document.MimeType, false)
 		if err != nil {
 			return "", nil, err
 		}
-		return caption, fileIDsOrNil(fileID), nil
+		return applyAttachmentMarker(caption, result), fileIDsOrNil(result.fileID), nil
 	}
 	if message.Audio != nil {
-		fileID, err := w.uploadTelegramFile(ctx, message.Audio.FileID, message.Audio.FileName, message.Audio.MimeType, false)
+		result, err := w.uploadTelegramFile(ctx, message.Audio.FileID, message.Audio.FileName, message.Audio.MimeType, false)
 		if err != nil {
 			return "", nil, err
 		}
-		return caption, fileIDsOrNil(fileID), nil
+		return applyAttachmentMarker(caption, result), fileIDsOrNil(result.fileID), nil
 	}
 	if message.Video != nil {
-		fileID, err := w.uploadTelegramFile(ctx, message.Video.FileID, message.Video.FileName, message.Video.MimeType, false)
+		result, err := w.uploadTelegramFile(ctx, message.Video.FileID, message.Video.FileName, message.Video.MimeType, false)
 		if err != nil {
 			return "", nil, err
 		}
-		return caption, fileIDsOrNil(fileID), nil
+		return applyAttachmentMarker(caption, result), fileIDsOrNil(result.fileID), nil
 	}
 	if message.Voice != nil {
-		fileID, err := w.uploadTelegramFile(ctx, message.Voice.FileID, "voice", message.Voice.MimeType, false)
+		result, err := w.uploadTelegramFile(ctx, message.Voice.FileID, "voice", message.Voice.MimeType, false)
 		if err != nil {
 			return "", nil, err
 		}
-		return caption, fileIDsOrNil(fileID), nil
+		return applyAttachmentMarker(caption, result), fileIDsOrNil(result.fileID), nil
 	}
 	if message.Sticker != nil {
 		label := "[sticker]"
@@ -357,6 +357,22 @@ func (w *installationWorker) buildInboundMessage(ctx context.Context, message *t
 	return "[unsupported message]", nil, nil
 }
 
+type uploadResult struct {
+	fileID     string
+	skipMarker string
+}
+
+func applyAttachmentMarker(caption string, result uploadResult) string {
+	marker := strings.TrimSpace(result.skipMarker)
+	if marker == "" {
+		return caption
+	}
+	if strings.TrimSpace(caption) == "" {
+		return marker
+	}
+	return fmt.Sprintf("%s\n%s", caption, marker)
+}
+
 func fileIDsOrNil(fileID string) []string {
 	if strings.TrimSpace(fileID) == "" {
 		return nil
@@ -366,43 +382,44 @@ func fileIDsOrNil(fileID string) []string {
 
 var errUploadContentTypeNotAllowed = errors.New("upload content_type not allowed")
 
-func (w *installationWorker) uploadTelegramFile(ctx context.Context, fileID, filename, mimeType string, requireImage bool) (string, error) {
+func (w *installationWorker) uploadTelegramFile(ctx context.Context, fileID, filename, mimeType string, requireImage bool) (uploadResult, error) {
 	file, err := w.telegramClient.GetFile(ctx, fileID)
 	if err != nil {
-		return "", err
+		return uploadResult{}, err
 	}
 	payload, headerContentType, err := w.telegramClient.DownloadFile(ctx, file.FilePath)
 	if err != nil {
-		return "", err
+		return uploadResult{}, err
 	}
 	sniffedContentType := http.DetectContentType(payload)
 	extensionType := extensionContentType(file.FilePath, filename)
 	candidates := buildContentTypeCandidates(mimeType, sniffedContentType, extensionType, headerContentType)
 	allowedContentTypes := selectAllowedContentTypes(candidates, requireImage)
-	if len(allowedContentTypes) == 0 {
-		w.logAttachmentSkipped(ctx, fileID, candidates)
-		return "", nil
-	}
 	if filename == "" {
 		filename = fileID
+	}
+	sizeBytes := int64(len(payload))
+	if len(allowedContentTypes) == 0 {
+		marker := w.handleAttachmentSkipped(ctx, fileID, filename, sizeBytes, candidates)
+		return uploadResult{skipMarker: marker}, nil
 	}
 	for _, contentType := range allowedContentTypes {
 		metadata := &filesv1.UploadFileMetadata{
 			Filename:    filename,
 			ContentType: contentType,
-			SizeBytes:   int64(len(payload)),
+			SizeBytes:   sizeBytes,
 		}
 		uploaded, err := w.uploadWithRetries(ctx, metadata, payload)
 		if err == nil {
-			return uploaded.GetId(), nil
+			return uploadResult{fileID: uploaded.GetId()}, nil
 		}
 		if errors.Is(err, errUploadContentTypeNotAllowed) {
 			continue
 		}
-		return "", err
+		return uploadResult{}, err
 	}
-	w.logAttachmentSkipped(ctx, fileID, candidates)
-	return "", nil
+	marker := w.handleAttachmentSkipped(ctx, fileID, filename, sizeBytes, candidates)
+	return uploadResult{skipMarker: marker}, nil
 }
 
 func (w *installationWorker) uploadWithRetries(ctx context.Context, metadata *filesv1.UploadFileMetadata, payload []byte) (*filesv1.FileInfo, error) {
@@ -456,7 +473,7 @@ func isUploadRetriableError(err error) bool {
 	return false
 }
 
-func (w *installationWorker) logAttachmentSkipped(ctx context.Context, fileID string, candidates []contentTypeCandidate) {
+func (w *installationWorker) handleAttachmentSkipped(ctx context.Context, fileID, filename string, sizeBytes int64, candidates []contentTypeCandidate) string {
 	summary := formatContentTypeCandidates(candidates)
 	if strings.TrimSpace(summary) == "" {
 		summary = "none"
@@ -472,6 +489,28 @@ func (w *installationWorker) logAttachmentSkipped(ctx context.Context, fileID st
 		level:          appsv1.InstallationAuditLogLevel_INSTALLATION_AUDIT_LOG_LEVEL_WARNING,
 		idempotencyKey: auditKeyWithHash(auditEventAttachmentSkipped, w.installation.ID, fmt.Sprintf("%s:%s", fileID, summary)),
 	})
+	return formatAttachmentSkippedMarker(filename, sizeBytes, candidates, summary)
+}
+
+func formatAttachmentSkippedMarker(filename string, sizeBytes int64, candidates []contentTypeCandidate, summary string) string {
+	summary = strings.TrimSpace(summary)
+	if summary == "none" {
+		summary = ""
+	}
+	contentType := strings.TrimSpace(bestContentTypeDetail(candidates))
+	if contentType == "" {
+		contentType = summary
+	}
+	if contentType == "" {
+		contentType = "unknown"
+	}
+	parts := make([]string, 0, 3)
+	if strings.TrimSpace(filename) != "" {
+		parts = append(parts, fmt.Sprintf("name=%s", filename))
+	}
+	parts = append(parts, fmt.Sprintf("size=%d", sizeBytes))
+	parts = append(parts, fmt.Sprintf("content_type=%s", contentType))
+	return fmt.Sprintf("[attachment skipped: unsupported file type (%s)]", strings.Join(parts, ", "))
 }
 
 func isThreadDegradedError(err error) bool {

--- a/internal/connector/inbound.go
+++ b/internal/connector/inbound.go
@@ -232,6 +232,10 @@ func (w *installationWorker) handleUpdate(ctx context.Context, update telegram.U
 	if err != nil {
 		return err
 	}
+	if strings.TrimSpace(body) == "" && len(fileIDs) == 0 {
+		log.Printf("connector: skip empty inbound message for chat %d", message.Chat.ID)
+		return nil
+	}
 	threadID := mapping.ThreadID
 	if err := w.gateway.SendMessage(ctx, threadID.String(), body, fileIDs); err != nil {
 		if !isThreadDegradedError(err) {
@@ -382,7 +386,6 @@ func (w *installationWorker) uploadTelegramFile(ctx context.Context, fileID, fil
 	if filename == "" {
 		filename = fileID
 	}
-	var contentTypeErr error
 	for _, contentType := range allowedContentTypes {
 		metadata := &filesv1.UploadFileMetadata{
 			Filename:    filename,
@@ -394,16 +397,12 @@ func (w *installationWorker) uploadTelegramFile(ctx context.Context, fileID, fil
 			return uploaded.GetId(), nil
 		}
 		if errors.Is(err, errUploadContentTypeNotAllowed) {
-			contentTypeErr = err
 			continue
 		}
 		return "", err
 	}
-	if contentTypeErr != nil {
-		w.logAttachmentSkipped(ctx, fileID, candidates)
-		return "", nil
-	}
-	return "", fmt.Errorf("upload file: no content type selected")
+	w.logAttachmentSkipped(ctx, fileID, candidates)
+	return "", nil
 }
 
 func (w *installationWorker) uploadWithRetries(ctx context.Context, metadata *filesv1.UploadFileMetadata, payload []byte) (*filesv1.FileInfo, error) {
@@ -433,14 +432,14 @@ func isUploadContentTypeNotAllowed(err error) bool {
 	if err == nil {
 		return false
 	}
-	if !strings.Contains(strings.ToLower(err.Error()), "content_type is not allowed") {
-		return false
-	}
 	var connectErr *connect.Error
 	if errors.As(err, &connectErr) {
-		return connectErr.Code() == connect.CodeInvalidArgument
+		if connectErr.Code() != connect.CodeInvalidArgument {
+			return false
+		}
+		return strings.Contains(strings.ToLower(connectErr.Message()), "content_type is not allowed")
 	}
-	return true
+	return strings.Contains(strings.ToLower(err.Error()), "content_type is not allowed")
 }
 
 func isUploadRetriableError(err error) bool {

--- a/internal/connector/inbound.go
+++ b/internal/connector/inbound.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"strings"
@@ -20,6 +21,7 @@ import (
 
 const (
 	inboundRetryDelay     = time.Second
+	inboundUploadRetryMax = 3
 	degradedThreadMessage = "thread is degraded"
 )
 
@@ -307,39 +309,39 @@ func (w *installationWorker) buildInboundMessage(ctx context.Context, message *t
 	caption := strings.TrimSpace(message.Caption)
 	if len(message.Photo) > 0 {
 		photo := largestPhoto(message.Photo)
-		fileID, err := w.uploadTelegramFile(ctx, photo.FileID, "photo", "image/jpeg")
+		fileID, err := w.uploadTelegramFile(ctx, photo.FileID, "photo", "image/jpeg", true)
 		if err != nil {
 			return "", nil, err
 		}
-		return caption, []string{fileID}, nil
+		return caption, fileIDsOrNil(fileID), nil
 	}
 	if message.Document != nil {
-		fileID, err := w.uploadTelegramFile(ctx, message.Document.FileID, message.Document.FileName, message.Document.MimeType)
+		fileID, err := w.uploadTelegramFile(ctx, message.Document.FileID, message.Document.FileName, message.Document.MimeType, false)
 		if err != nil {
 			return "", nil, err
 		}
-		return caption, []string{fileID}, nil
+		return caption, fileIDsOrNil(fileID), nil
 	}
 	if message.Audio != nil {
-		fileID, err := w.uploadTelegramFile(ctx, message.Audio.FileID, message.Audio.FileName, message.Audio.MimeType)
+		fileID, err := w.uploadTelegramFile(ctx, message.Audio.FileID, message.Audio.FileName, message.Audio.MimeType, false)
 		if err != nil {
 			return "", nil, err
 		}
-		return caption, []string{fileID}, nil
+		return caption, fileIDsOrNil(fileID), nil
 	}
 	if message.Video != nil {
-		fileID, err := w.uploadTelegramFile(ctx, message.Video.FileID, message.Video.FileName, message.Video.MimeType)
+		fileID, err := w.uploadTelegramFile(ctx, message.Video.FileID, message.Video.FileName, message.Video.MimeType, false)
 		if err != nil {
 			return "", nil, err
 		}
-		return caption, []string{fileID}, nil
+		return caption, fileIDsOrNil(fileID), nil
 	}
 	if message.Voice != nil {
-		fileID, err := w.uploadTelegramFile(ctx, message.Voice.FileID, "voice", message.Voice.MimeType)
+		fileID, err := w.uploadTelegramFile(ctx, message.Voice.FileID, "voice", message.Voice.MimeType, false)
 		if err != nil {
 			return "", nil, err
 		}
-		return caption, []string{fileID}, nil
+		return caption, fileIDsOrNil(fileID), nil
 	}
 	if message.Sticker != nil {
 		label := "[sticker]"
@@ -351,34 +353,126 @@ func (w *installationWorker) buildInboundMessage(ctx context.Context, message *t
 	return "[unsupported message]", nil, nil
 }
 
-func (w *installationWorker) uploadTelegramFile(ctx context.Context, fileID, filename, mimeType string) (string, error) {
+func fileIDsOrNil(fileID string) []string {
+	if strings.TrimSpace(fileID) == "" {
+		return nil
+	}
+	return []string{fileID}
+}
+
+var errUploadContentTypeNotAllowed = errors.New("upload content_type not allowed")
+
+func (w *installationWorker) uploadTelegramFile(ctx context.Context, fileID, filename, mimeType string, requireImage bool) (string, error) {
 	file, err := w.telegramClient.GetFile(ctx, fileID)
 	if err != nil {
 		return "", err
 	}
-	payload, contentType, err := w.telegramClient.DownloadFile(ctx, file.FilePath)
+	payload, headerContentType, err := w.telegramClient.DownloadFile(ctx, file.FilePath)
 	if err != nil {
 		return "", err
 	}
-	if contentType == "" {
-		contentType = mimeType
-	}
-	if contentType == "" {
-		contentType = "application/octet-stream"
+	sniffedContentType := http.DetectContentType(payload)
+	extensionType := extensionContentType(file.FilePath, filename)
+	candidates := buildContentTypeCandidates(mimeType, sniffedContentType, extensionType, headerContentType)
+	allowedContentTypes := selectAllowedContentTypes(candidates, requireImage)
+	if len(allowedContentTypes) == 0 {
+		w.logAttachmentSkipped(ctx, fileID, candidates)
+		return "", nil
 	}
 	if filename == "" {
 		filename = fileID
 	}
-	metadata := &filesv1.UploadFileMetadata{
-		Filename:    filename,
-		ContentType: contentType,
-		SizeBytes:   int64(len(payload)),
-	}
-	uploaded, err := w.gateway.UploadFile(ctx, metadata, payload)
-	if err != nil {
+	var contentTypeErr error
+	for _, contentType := range allowedContentTypes {
+		metadata := &filesv1.UploadFileMetadata{
+			Filename:    filename,
+			ContentType: contentType,
+			SizeBytes:   int64(len(payload)),
+		}
+		uploaded, err := w.uploadWithRetries(ctx, metadata, payload)
+		if err == nil {
+			return uploaded.GetId(), nil
+		}
+		if errors.Is(err, errUploadContentTypeNotAllowed) {
+			contentTypeErr = err
+			continue
+		}
 		return "", err
 	}
-	return uploaded.GetId(), nil
+	if contentTypeErr != nil {
+		w.logAttachmentSkipped(ctx, fileID, candidates)
+		return "", nil
+	}
+	return "", fmt.Errorf("upload file: no content type selected")
+}
+
+func (w *installationWorker) uploadWithRetries(ctx context.Context, metadata *filesv1.UploadFileMetadata, payload []byte) (*filesv1.FileInfo, error) {
+	attempts := 0
+	for {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		uploaded, err := w.gateway.UploadFile(ctx, metadata, payload)
+		if err == nil {
+			return uploaded, nil
+		}
+		if isUploadContentTypeNotAllowed(err) {
+			return nil, errUploadContentTypeNotAllowed
+		}
+		attempts++
+		if !isUploadRetriableError(err) || attempts >= inboundUploadRetryMax {
+			return nil, err
+		}
+		if !sleepContext(ctx, retryDelay(attempts)) {
+			return nil, ctx.Err()
+		}
+	}
+}
+
+func isUploadContentTypeNotAllowed(err error) bool {
+	if err == nil {
+		return false
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "content_type is not allowed") {
+		return false
+	}
+	var connectErr *connect.Error
+	if errors.As(err, &connectErr) {
+		return connectErr.Code() == connect.CodeInvalidArgument
+	}
+	return true
+}
+
+func isUploadRetriableError(err error) bool {
+	if errors.Is(err, io.EOF) {
+		return true
+	}
+	var connectErr *connect.Error
+	if errors.As(err, &connectErr) {
+		switch connectErr.Code() {
+		case connect.CodeUnavailable, connect.CodeDeadlineExceeded, connect.CodeInternal:
+			return true
+		}
+	}
+	return false
+}
+
+func (w *installationWorker) logAttachmentSkipped(ctx context.Context, fileID string, candidates []contentTypeCandidate) {
+	summary := formatContentTypeCandidates(candidates)
+	if strings.TrimSpace(summary) == "" {
+		summary = "none"
+	}
+	message := fmt.Sprintf("%s: file_id=%s content_types=%s", auditEventAttachmentSkipped, fileID, summary)
+	log.Printf("connector: attachment skipped: file_id=%s content_types=%s", fileID, summary)
+	if w.status != nil {
+		w.status.RecordError(time.Now().UTC(), message)
+	}
+	w.appendAudit(ctx, auditEvent{
+		name:           auditEventAttachmentSkipped,
+		message:        message,
+		level:          appsv1.InstallationAuditLogLevel_INSTALLATION_AUDIT_LOG_LEVEL_WARNING,
+		idempotencyKey: auditKeyWithHash(auditEventAttachmentSkipped, w.installation.ID, fmt.Sprintf("%s:%s", fileID, summary)),
+	})
 }
 
 func isThreadDegradedError(err error) bool {

--- a/internal/connector/inbound_test.go
+++ b/internal/connector/inbound_test.go
@@ -447,7 +447,7 @@ func TestHandleUpdateStopsAfterSecondDegradedSend(t *testing.T) {
 	}
 }
 
-func TestHandleUpdateSkipsEmptyMessageAfterAttachmentSkip(t *testing.T) {
+func TestHandleUpdateAttachmentSkipSendsMarkerWithoutCaption(t *testing.T) {
 	installationID := uuid.New()
 	organizationID := uuid.New()
 	agentID := uuid.New()
@@ -482,8 +482,26 @@ func TestHandleUpdateSkipsEmptyMessageAfterAttachmentSkip(t *testing.T) {
 	}
 	gatewayStub := &stubGateway{
 		t: t,
-		sendMessageFn: func(context.Context, string, string, []string) error {
+		sendMessageFn: func(_ context.Context, threadArg, body string, fileIDs []string) error {
 			sendCalled = true
+			if threadArg != threadID.String() {
+				t.Fatalf("expected thread %s, got %s", threadID, threadArg)
+			}
+			if len(fileIDs) != 0 {
+				t.Fatalf("expected no file IDs, got %v", fileIDs)
+			}
+			if !strings.Contains(body, "attachment skipped: unsupported file type") {
+				t.Fatalf("expected marker in body, got %s", body)
+			}
+			if !strings.Contains(body, "name=file.bin") {
+				t.Fatalf("expected filename in body, got %s", body)
+			}
+			if !strings.Contains(body, "size=512") {
+				t.Fatalf("expected size in body, got %s", body)
+			}
+			if !strings.Contains(body, "content_type=application/octet-stream") {
+				t.Fatalf("expected content type in body, got %s", body)
+			}
 			return nil
 		},
 		appendAuditFn: func(_ context.Context, installationArg, message string, level appsv1.InstallationAuditLogLevel, idempotencyKey string) error {
@@ -519,10 +537,82 @@ func TestHandleUpdateSkipsEmptyMessageAfterAttachmentSkip(t *testing.T) {
 	if err := worker.handleUpdate(context.Background(), update); err != nil {
 		t.Fatalf("handleUpdate returned error: %v", err)
 	}
-	if sendCalled {
-		t.Fatal("expected SendMessage not to be called")
+	if !sendCalled {
+		t.Fatal("expected SendMessage to be called")
 	}
 	if !auditCalled {
 		t.Fatal("expected audit log call")
+	}
+}
+
+func TestHandleUpdateAttachmentSkipAppendsMarkerToCaption(t *testing.T) {
+	installationID := uuid.New()
+	organizationID := uuid.New()
+	agentID := uuid.New()
+	chatID := int64(56)
+	userID := int64(100)
+	threadID := uuid.New()
+	fileID := "file-456"
+	filePath := "files/" + fileID + ".bin"
+	data := make([]byte, 256)
+	caption := "caption text"
+
+	server := newTelegramFileServer(t, "token", fileID, filePath, "application/octet-stream", data)
+	defer server.Close()
+
+	storeStub := &stubStore{
+		t: t,
+		getChatMappingFn: func(_ context.Context, installationArg uuid.UUID, chatIDArg int64) (store.ChatMapping, bool, error) {
+			return store.ChatMapping{
+				InstallationID: installationID,
+				TelegramChatID: chatID,
+				TelegramUserID: userID,
+				ThreadID:       threadID,
+			}, true, nil
+		},
+	}
+	gatewayStub := &stubGateway{
+		t: t,
+		sendMessageFn: func(_ context.Context, threadArg, body string, fileIDs []string) error {
+			if threadArg != threadID.String() {
+				t.Fatalf("expected thread %s, got %s", threadID, threadArg)
+			}
+			if len(fileIDs) != 0 {
+				t.Fatalf("expected no file IDs, got %v", fileIDs)
+			}
+			if !strings.HasPrefix(body, caption+"\n") {
+				t.Fatalf("expected caption prefix, got %s", body)
+			}
+			if !strings.Contains(body, "attachment skipped: unsupported file type") {
+				t.Fatalf("expected marker in body, got %s", body)
+			}
+			return nil
+		},
+		appendAuditFn: func(context.Context, string, string, appsv1.InstallationAuditLogLevel, string) error {
+			return nil
+		},
+	}
+
+	worker := newInstallationWorker(Installation{
+		ID:             installationID,
+		OrganizationID: organizationID,
+		BotToken:       "token",
+		AgentID:        agentID,
+	}, storeStub, gatewayStub, server.URL, time.Second)
+
+	update := telegram.Update{Message: &telegram.Message{
+		From:    &telegram.User{ID: userID},
+		Chat:    telegram.Chat{ID: chatID, Type: "private"},
+		Caption: caption,
+		Document: &telegram.Document{
+			FileID:   fileID,
+			FileName: "file.bin",
+			MimeType: "",
+			FileSize: int64(len(data)),
+		},
+	}}
+
+	if err := worker.handleUpdate(context.Background(), update); err != nil {
+		t.Fatalf("handleUpdate returned error: %v", err)
 	}
 }

--- a/internal/connector/inbound_test.go
+++ b/internal/connector/inbound_test.go
@@ -446,3 +446,83 @@ func TestHandleUpdateStopsAfterSecondDegradedSend(t *testing.T) {
 		t.Fatalf("handleUpdate returned error: %v", err)
 	}
 }
+
+func TestHandleUpdateSkipsEmptyMessageAfterAttachmentSkip(t *testing.T) {
+	installationID := uuid.New()
+	organizationID := uuid.New()
+	agentID := uuid.New()
+	chatID := int64(55)
+	userID := int64(99)
+	threadID := uuid.New()
+	fileID := "file-123"
+	filePath := "files/" + fileID + ".bin"
+	data := make([]byte, 512)
+
+	server := newTelegramFileServer(t, "token", fileID, filePath, "application/octet-stream", data)
+	defer server.Close()
+
+	sendCalled := false
+	auditCalled := false
+	storeStub := &stubStore{
+		t: t,
+		getChatMappingFn: func(_ context.Context, installationArg uuid.UUID, chatIDArg int64) (store.ChatMapping, bool, error) {
+			if installationArg != installationID {
+				t.Fatalf("expected installation %s, got %s", installationID, installationArg)
+			}
+			if chatIDArg != chatID {
+				t.Fatalf("expected chat %d, got %d", chatID, chatIDArg)
+			}
+			return store.ChatMapping{
+				InstallationID: installationID,
+				TelegramChatID: chatID,
+				TelegramUserID: userID,
+				ThreadID:       threadID,
+			}, true, nil
+		},
+	}
+	gatewayStub := &stubGateway{
+		t: t,
+		sendMessageFn: func(context.Context, string, string, []string) error {
+			sendCalled = true
+			return nil
+		},
+		appendAuditFn: func(_ context.Context, installationArg, message string, level appsv1.InstallationAuditLogLevel, idempotencyKey string) error {
+			auditCalled = true
+			if installationArg != installationID.String() {
+				t.Fatalf("expected installation %s, got %s", installationID, installationArg)
+			}
+			if strings.TrimSpace(idempotencyKey) == "" {
+				t.Fatal("expected idempotency key")
+			}
+			return nil
+		},
+	}
+
+	worker := newInstallationWorker(Installation{
+		ID:             installationID,
+		OrganizationID: organizationID,
+		BotToken:       "token",
+		AgentID:        agentID,
+	}, storeStub, gatewayStub, server.URL, time.Second)
+
+	update := telegram.Update{Message: &telegram.Message{
+		From: &telegram.User{ID: userID},
+		Chat: telegram.Chat{ID: chatID, Type: "private"},
+		Document: &telegram.Document{
+			FileID:   fileID,
+			FileName: "file.bin",
+			MimeType: "",
+			FileSize: int64(len(data)),
+		},
+	}}
+
+	if err := worker.handleUpdate(context.Background(), update); err != nil {
+		t.Fatalf("handleUpdate returned error: %v", err)
+	}
+	if sendCalled {
+		t.Fatal("expected SendMessage not to be called")
+	}
+	if !auditCalled {
+		t.Fatal("expected audit log call")
+	}
+}

--- a/test/e2e/inbound_test.go
+++ b/test/e2e/inbound_test.go
@@ -31,7 +31,7 @@ func TestInboundMedia(t *testing.T) {
 	filePath := "photos/" + fileID + ".jpg"
 	data := []byte("photo-data-" + uuid.NewString())
 
-	setTelegramFile(t, botToken, fileID, filePath, "image/jpeg", data)
+	setTelegramFile(t, botToken, fileID, filePath, "application/octet-stream", data)
 	enqueuePhotoUpdate(t, botToken, chatID, fileID, caption, int64(len(data)))
 	_, message := waitForMessage(t, caption, 1, 90*time.Second)
 
@@ -39,6 +39,7 @@ func TestInboundMedia(t *testing.T) {
 	uploadedID := message.GetFileIds()[0]
 	metadata := getFileMetadata(t, uploadedID)
 	require.Equal(t, int64(len(data)), metadata.GetSizeBytes())
+	require.Equal(t, "image/jpeg", metadata.GetContentType())
 	downloaded := downloadFile(t, uploadedID)
 	require.Equal(t, data, downloaded)
 }


### PR DESCRIPTION
## Summary
- add allowed-aware content-type selection for inbound media uploads with retries and skip/audit logging
- add unit coverage for content-type selection and skip behavior
- update inbound e2e media test for octet-stream headers

## Testing
- go vet ./...
- go test ./...
- go test -tags e2e ./test/e2e

Closes #11