### PR TITLE
Add room-scoped notifications subscribe

### DIFF
--- a/internal/gateway/client.go
+++ b/internal/gateway/client.go
@@ -256,5 +256,12 @@ func (c *Client) GetFileContent(ctx context.Context, fileID string) ([]byte, err
 }
 
 func (c *Client) Subscribe(ctx context.Context) (*connect.ServerStreamForClient[notificationsv1.SubscribeResponse], error) {
-	return c.notifications.Subscribe(ctx, connect.NewRequest(&notificationsv1.SubscribeRequest{}))
+	appIdentityID := strings.TrimSpace(c.appIdentityID)
+	if appIdentityID == "" {
+		return nil, fmt.Errorf("subscribe notifications: app identity id required")
+	}
+	request := &notificationsv1.SubscribeRequest{
+		Rooms: []string{fmt.Sprintf("thread_participant:%s", appIdentityID)},
+	}
+	return c.notifications.Subscribe(ctx, connect.NewRequest(request))
 }


### PR DESCRIPTION
## Summary
- include room-scoped Subscribe requests for notifications using the app identity

## Room list derivation
Rooms are derived from the connector app identity as `thread_participant:{app_identity_id}`.

## Testing
- go vet ./...
- go test ./...

Refs https://github.com/agynio/architecture/issues/142 (#142)